### PR TITLE
캐시 무효화를 위한 글로벌 태그 전략 적용 및 hydration mismatch 대응

### DIFF
--- a/src/app/actions/keys.ts
+++ b/src/app/actions/keys.ts
@@ -46,8 +46,8 @@ export const logKeys = {
       `${params.pageSize}`,
       `${params.sort}`,
     ] as const,
-  listByUser: ({ userId, currentPage, pageSize }: LogsParams) =>
-    [...logKeys.log, 'byUser', userId, `${currentPage}`, `${pageSize}`] as const,
+  listByUser: ({ userId, currentPage = 1, pageSize = 10 }: LogsParams) =>
+    [...logKeys.log, 'byUser', userId ?? '', `${currentPage}`, `${pageSize}`] as const,
   bookmarkList: ({ userId, currentPage, pageSize }: logBookmarkListParmas) =>
     [...logKeys.log, 'bookmark', `${userId}`, `${currentPage}`, `${pageSize}`] as const,
 
@@ -60,7 +60,8 @@ export const logKeys = {
 export const placeKeys = {
   place: ['place'] as const,
   detail: (placeId: string) => [...placeKeys.place, placeId] as const,
-  list: (params: PaginationParams) => [...placeKeys.place, 'list', params] as const,
+  list: ({ currentPage = 1, pageSize = 10 }: PaginationParams) =>
+    [...placeKeys.place, 'list', `${currentPage}`, `${pageSize}`] as const,
   bookmarkList: ({ userId, currentPage, pageSize }: logBookmarkListParmas) =>
     [...placeKeys.place, 'bookmark', `${userId}`, `${currentPage}`, `${pageSize}`] as const,
 

--- a/src/app/actions/log-update.ts
+++ b/src/app/actions/log-update.ts
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/server';
 import { LogEditFormValues } from '@/types/schema/log';
 import { parseFormData } from '@/utils/formatLog';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from './tags';
+import { globalTags } from './tags';
 import { getUser } from './user';
 
 export async function updateLog(formData: FormData, logId: string) {
@@ -122,9 +122,13 @@ export async function updateLog(formData: FormData, logId: string) {
     }
     //서버 캐시 무효화
     const tagsToInvalidate = [
-      cacheTags.logBookmark(logId),
-      cacheTags.logBookmarkList(String(me?.user_id)),
-      cacheTags.logListByUser(String(me?.user_id)),
+      globalTags.logAll,
+      globalTags.logBookmarkAll,
+      globalTags.logListAll,
+      globalTags.placeAll,
+      globalTags.placeBookmarkAll,
+      globalTags.placeListAll,
+      globalTags.searchAll,
     ];
     tagsToInvalidate.forEach((tag) => revalidateTag(tag));
     return { success: true };

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -115,12 +115,15 @@ export async function fetchBookmarkedPlaces({
 
 export async function getBookmarkedPlaces(params: PlaceBookmarkListParmas) {
   return unstable_cache(() => fetchBookmarkedPlaces(params), [...logKeys.bookmarkList(params)], {
-    tags: [cacheTags.placeBookmarkList(params.userId)],
+    tags: [
+      cacheTags.placeBookmarkList(params), // 개별 사용자별 태그
+      'place:bookmark:all', // 전체 북마크 무효화용 태그
+    ],
     revalidate: 300,
   })();
 }
 
 /* 북마크 시 서버캐시 무효화 */
-export async function revalidateBookmarkPlaces(userId: string) {
-  revalidateTag(cacheTags.placeBookmarkList(userId));
+export async function revalidateBookmarkPlaces() {
+  revalidateTag('place:bookmark:all');
 }

--- a/src/app/actions/tags.ts
+++ b/src/app/actions/tags.ts
@@ -1,5 +1,31 @@
+import { PaginationParams } from '@/types/api/common';
+import { logBookmarkListParmas, LogsParams } from '@/types/api/log';
 import { SearchParams } from '@/types/api/search';
 import { followKeys, logKeys, placeKeys, searchKeys, userKeys } from './keys';
+
+/* 해당 태그 관련 전체 무효화용 */
+export const globalTags = {
+  /* 유저 관련 */
+  userAll: 'user:all',
+
+  /* 팔로우 관련 */
+  followAll: 'follow:all',
+  followerAll: 'follow:follower:all',
+  followingAll: 'follow:following:all',
+
+  /* 로그 관련 */
+  logAll: 'log:all',
+  logListAll: 'log:list:all',
+  logBookmarkAll: 'log:bookmark:all',
+
+  /* 장소 관련 */
+  placeAll: 'place:all',
+  placeListAll: 'place:list:all',
+  placeBookmarkAll: 'place:bookmark:all',
+
+  /* 검색 관련 */
+  searchAll: 'search:list:all',
+};
 
 export const cacheTags = {
   // 캐시키 배열을 문자열로 변환
@@ -17,17 +43,17 @@ export const cacheTags = {
 
   /* 로그 */
   logDetail: (logId: string) => cacheTags.fromKey([...logKeys.detail(logId), 'single']),
-  logList: () => cacheTags.fromKey([...logKeys.log, 'list']),
-  logListByUser: (userId: string) => cacheTags.fromKey([...logKeys.log, 'byUser', userId, 'list']),
-  logBookmarkList: (userId: string) =>
-    cacheTags.fromKey([...logKeys.log, 'bookmark', userId, 'list']),
+  logList: (params: LogsParams) => cacheTags.fromKey(logKeys.list(params)),
+  logListByUser: (params: LogsParams) => cacheTags.fromKey(logKeys.listByUser(params)),
+  logBookmarkList: (params: logBookmarkListParmas) =>
+    cacheTags.fromKey(logKeys.bookmarkList(params)),
   logMyList: (userId: string) => cacheTags.fromKey([...logKeys.log, 'myList', userId, 'list']),
 
   /* 장소 */
   placeDetail: (placeId: string) => cacheTags.fromKey([...placeKeys.detail(placeId), 'single']),
-  placeList: () => cacheTags.fromKey([...placeKeys.place, 'list']),
-  placeBookmarkList: (userId: string) =>
-    cacheTags.fromKey([...placeKeys.place, 'bookmark', userId, 'list']),
+  placeList: (params: PaginationParams) => cacheTags.fromKey(placeKeys.list(params)),
+  placeBookmarkList: (params: logBookmarkListParmas) =>
+    cacheTags.fromKey(placeKeys.bookmarkList(params)),
 
   /* 북마크 */
   placeBookmark: (placeId: string) =>

--- a/src/app/actions/user.ts
+++ b/src/app/actions/user.ts
@@ -8,7 +8,7 @@ import { revalidateTag, unstable_cache } from 'next/cache';
 import { prisma } from 'prisma/prisma';
 import { userKeys } from './keys';
 import { deleteProfileStorageFolder } from './storage';
-import { cacheTags } from './tags';
+import { cacheTags, globalTags } from './tags';
 
 interface PatchUserProps {
   userId: string;
@@ -193,20 +193,18 @@ export async function deleteUser() {
       },
     });
     /* 캐시 무효화 */
-    const userTagsToInvalidate = [
-      cacheTags.me(),
-      cacheTags.publicUser(me.user_id),
-      cacheTags.follower(me.user_id),
-      cacheTags.followerList(me.user_id),
-      cacheTags.following(me.user_id),
-      cacheTags.followingList(me.user_id),
-      cacheTags.logListByUser(me.user_id),
-      cacheTags.logBookmarkList(me.user_id),
-      cacheTags.logMyList(me.user_id),
-      cacheTags.placeBookmarkList(me.user_id),
-      'search',
+    const tagsToInvalidate = [
+      globalTags.userAll,
+      globalTags.followAll,
+      globalTags.logAll,
+      globalTags.logListAll,
+      globalTags.logBookmarkAll,
+      globalTags.placeAll,
+      globalTags.placeListAll,
+      globalTags.placeBookmarkAll,
+      globalTags.searchAll,
     ];
-    userTagsToInvalidate.forEach((tag) => revalidateTag(tag));
+    tagsToInvalidate.forEach(revalidateTag);
     return { success: true, msg: ERROR_MESSAGES.USER.DELETE_SUCCESS };
   } catch (error) {
     console.error('유저 삭제 오류', error);

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/MyLogs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/MyLogs.tsx
@@ -35,7 +35,7 @@ export default function MyLogs({ userId }: MyLogsProps) {
     if (!me?.user_id) return;
 
     const revalidateAndRefetch = async () => {
-      await revalidateBookmarkLogs(String(me.user_id));
+      await revalidateBookmarkLogs();
       refetch();
     };
 

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SaveLogs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SaveLogs.tsx
@@ -39,7 +39,7 @@ export default function SaveLogs({ userId }: SavaLogsProps) {
     if (!me?.user_id) return;
 
     const revalidateAndRefetch = async () => {
-      await revalidateBookmarkLogs(String(me.user_id));
+      await revalidateBookmarkLogs();
       refetch();
     };
 

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SavePlaces.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SavePlaces.tsx
@@ -34,7 +34,7 @@ export default function SavePlaces({ userId }: SavePlacesProps) {
     if (!me?.user_id) return;
 
     const revalidateAndRefetch = async () => {
-      await revalidateBookmarkPlaces(String(me.user_id));
+      await revalidateBookmarkPlaces();
       refetch();
     };
 


### PR DESCRIPTION
## 📌 작업 주제

* SSR 캐시 무효화 전략 개선 및 hydration mismatch 대응

## 🛠 작업 내용

* `unstable_cache`의 `tags` 옵션에 `globalTags`를 적용하여 SSR 캐시를 그룹 단위로 관리
  예: `'log:list:all'`, `'place:bookmark:all'` 등
* 기존 `cacheTags` 함수에서 **params 객체 전체를 태그 키로 사용하는 방식 제거**

  * 버그 발생 원인: `params` 객체 내 `undefined`, 객체 타입이 문자열 변환되지 않아 hydration mismatch 발생
  * 개선: `userId` 등 필수 식별자만을 명시적으로 추출하여 string 또는 number만 포함하는 태그 키 구성
* 쿼리 키(`queryKey`)와 태그 키(`tagKey`)가 불일치해 발생하던 hydration mismatch 문제 해결

  * `logListByUser`, `logBookmarkList`, `placeList` 등에서 구조 통일
* 로그/북마크/장소 삭제 등에서 관련 그룹 캐시만 정확히 무효화되도록 `globalTags` 기반으로 재구성
* `deleteLog`, `deleteUser`, `toggleBookmark` 등 API 전반에 재사용 가능한 글로벌 태그 무효화 전략 도입

## 📚 추가 내용 (선택)

* SSR과 CSR이 쿼리 키 기준으로 정확히 일치하게 되어 렌더 mismatch 및 깜빡임 현상 방지 가능
