### PR TITLE
SSR/CSR 쿼리 키 불일치로 인한 hydration mismatch 및 캐시 무효화 전략 개선

### DIFF
--- a/src/app/(root)/log/[logId]/page.tsx
+++ b/src/app/(root)/log/[logId]/page.tsx
@@ -1,5 +1,5 @@
 import { fetchLog } from '@/app/actions/log';
-import { getUser } from '@/app/actions/user';
+import { getPublicUser, getUser } from '@/app/actions/user';
 import LogBookMarkButton from '@/components/common/Button/Bookmark/LogBookMarkButton';
 import { PenBlackIcon, TableIcon } from '@/components/common/Icons';
 import ExtraActionButton from '@/components/features/detail-log/ExtraActionButton';
@@ -24,12 +24,13 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
   }
   const { data: logData } = result;
   const user = await getUser();
+  const logUser = await getPublicUser(result.data.user_id);
   const isAuthor = user?.user_id === logData.user_id;
   return (
     <div>
       <LogThubmnail logData={logData} isAuthor={isAuthor} />
       <main className="flex flex-col px-4 web:px-[50px]">
-        <LogAuthorIntro userId={logData.user_id} logDescription={logData.description ?? ''} />
+        <LogAuthorIntro user={logUser} logDescription={logData.description ?? ''} />
         {logData.place.map((place: PlaceWithImages, idx: number) => (
           <LogContent key={place.place_id} place={place} idx={idx + 1} />
         ))}

--- a/src/app/(root)/profile/editor/page.tsx
+++ b/src/app/(root)/profile/editor/page.tsx
@@ -87,7 +87,12 @@ export default function ProfileEditorPage() {
             me.image_url.startsWith('profiles/')) && // 상대 경로
           !me.image_url.includes('user-default-avatar') // 기본 이미지가 아님
         ) {
-          await removeImageIfNeeded(me.image_url, 'profiles');
+          try {
+            await removeImageIfNeeded(me.image_url, 'profiles');
+          } catch (error) {
+            console.warn('기존 이미지 삭제 실패:', error);
+            return;
+          }
         }
 
         /** 2.새 이미지 압축 */
@@ -126,6 +131,8 @@ export default function ProfileEditorPage() {
 
       router.push(`/profile/${me.user_id}`);
       toast.success('회원 정보 수정 성공');
+    } catch (_error) {
+      toast.error('회원 정보 수정 실패');
     } finally {
       setIsSubmitting(false);
     }

--- a/src/app/actions/keys.ts
+++ b/src/app/actions/keys.ts
@@ -46,8 +46,8 @@ export const logKeys = {
       `${params.pageSize}`,
       `${params.sort}`,
     ] as const,
-  listByUser: ({ userId, currentPage, pageSize }: LogsParams) =>
-    [...logKeys.log, 'byUser', userId, `${currentPage}`, `${pageSize}`] as const,
+  listByUser: ({ userId, currentPage = 1, pageSize = 10 }: LogsParams) =>
+    [...logKeys.log, 'byUser', userId ?? '', `${currentPage}`, `${pageSize}`] as const,
   bookmarkList: ({ userId, currentPage, pageSize }: logBookmarkListParmas) =>
     [...logKeys.log, 'bookmark', `${userId}`, `${currentPage}`, `${pageSize}`] as const,
 
@@ -60,7 +60,8 @@ export const logKeys = {
 export const placeKeys = {
   place: ['place'] as const,
   detail: (placeId: string) => [...placeKeys.place, placeId] as const,
-  list: (params: PaginationParams) => [...placeKeys.place, 'list', params] as const,
+  list: ({ currentPage = 1, pageSize = 10 }: PaginationParams) =>
+    [...placeKeys.place, 'list', `${currentPage}`, `${pageSize}`] as const,
   bookmarkList: ({ userId, currentPage, pageSize }: logBookmarkListParmas) =>
     [...placeKeys.place, 'bookmark', `${userId}`, `${currentPage}`, `${pageSize}`] as const,
 

--- a/src/app/actions/log-update.ts
+++ b/src/app/actions/log-update.ts
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/server';
 import { LogEditFormValues } from '@/types/schema/log';
 import { parseFormData } from '@/utils/formatLog';
 import { revalidateTag } from 'next/cache';
-import { cacheTags } from './tags';
+import { globalTags } from './tags';
 import { getUser } from './user';
 
 export async function updateLog(formData: FormData, logId: string) {
@@ -122,9 +122,13 @@ export async function updateLog(formData: FormData, logId: string) {
     }
     //서버 캐시 무효화
     const tagsToInvalidate = [
-      cacheTags.logBookmark(logId),
-      cacheTags.logBookmarkList(String(me?.user_id)),
-      cacheTags.logListByUser(String(me?.user_id)),
+      globalTags.logAll,
+      globalTags.logBookmarkAll,
+      globalTags.logListAll,
+      globalTags.placeAll,
+      globalTags.placeBookmarkAll,
+      globalTags.placeListAll,
+      globalTags.searchAll,
     ];
     tagsToInvalidate.forEach((tag) => revalidateTag(tag));
     return { success: true };

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -115,12 +115,15 @@ export async function fetchBookmarkedPlaces({
 
 export async function getBookmarkedPlaces(params: PlaceBookmarkListParmas) {
   return unstable_cache(() => fetchBookmarkedPlaces(params), [...logKeys.bookmarkList(params)], {
-    tags: [cacheTags.placeBookmarkList(params.userId)],
+    tags: [
+      cacheTags.placeBookmarkList(params), // 개별 사용자별 태그
+      'place:bookmark:all', // 전체 북마크 무효화용 태그
+    ],
     revalidate: 300,
   })();
 }
 
 /* 북마크 시 서버캐시 무효화 */
-export async function revalidateBookmarkPlaces(userId: string) {
-  revalidateTag(cacheTags.placeBookmarkList(userId));
+export async function revalidateBookmarkPlaces() {
+  revalidateTag('place:bookmark:all');
 }

--- a/src/app/actions/tags.ts
+++ b/src/app/actions/tags.ts
@@ -1,5 +1,31 @@
+import { PaginationParams } from '@/types/api/common';
+import { logBookmarkListParmas, LogsParams } from '@/types/api/log';
 import { SearchParams } from '@/types/api/search';
 import { followKeys, logKeys, placeKeys, searchKeys, userKeys } from './keys';
+
+/* 해당 태그 관련 전체 무효화용 */
+export const globalTags = {
+  /* 유저 관련 */
+  userAll: 'user:all',
+
+  /* 팔로우 관련 */
+  followAll: 'follow:all',
+  followerAll: 'follow:follower:all',
+  followingAll: 'follow:following:all',
+
+  /* 로그 관련 */
+  logAll: 'log:all',
+  logListAll: 'log:list:all',
+  logBookmarkAll: 'log:bookmark:all',
+
+  /* 장소 관련 */
+  placeAll: 'place:all',
+  placeListAll: 'place:list:all',
+  placeBookmarkAll: 'place:bookmark:all',
+
+  /* 검색 관련 */
+  searchAll: 'search:list:all',
+};
 
 export const cacheTags = {
   // 캐시키 배열을 문자열로 변환
@@ -17,17 +43,17 @@ export const cacheTags = {
 
   /* 로그 */
   logDetail: (logId: string) => cacheTags.fromKey([...logKeys.detail(logId), 'single']),
-  logList: () => cacheTags.fromKey([...logKeys.log, 'list']),
-  logListByUser: (userId: string) => cacheTags.fromKey([...logKeys.log, 'byUser', userId, 'list']),
-  logBookmarkList: (userId: string) =>
-    cacheTags.fromKey([...logKeys.log, 'bookmark', userId, 'list']),
+  logList: (params: LogsParams) => cacheTags.fromKey(logKeys.list(params)),
+  logListByUser: (params: LogsParams) => cacheTags.fromKey(logKeys.listByUser(params)),
+  logBookmarkList: (params: logBookmarkListParmas) =>
+    cacheTags.fromKey(logKeys.bookmarkList(params)),
   logMyList: (userId: string) => cacheTags.fromKey([...logKeys.log, 'myList', userId, 'list']),
 
   /* 장소 */
   placeDetail: (placeId: string) => cacheTags.fromKey([...placeKeys.detail(placeId), 'single']),
-  placeList: () => cacheTags.fromKey([...placeKeys.place, 'list']),
-  placeBookmarkList: (userId: string) =>
-    cacheTags.fromKey([...placeKeys.place, 'bookmark', userId, 'list']),
+  placeList: (params: PaginationParams) => cacheTags.fromKey(placeKeys.list(params)),
+  placeBookmarkList: (params: logBookmarkListParmas) =>
+    cacheTags.fromKey(placeKeys.bookmarkList(params)),
 
   /* 북마크 */
   placeBookmark: (placeId: string) =>

--- a/src/app/actions/user.ts
+++ b/src/app/actions/user.ts
@@ -8,7 +8,7 @@ import { revalidateTag, unstable_cache } from 'next/cache';
 import { prisma } from 'prisma/prisma';
 import { userKeys } from './keys';
 import { deleteProfileStorageFolder } from './storage';
-import { cacheTags } from './tags';
+import { cacheTags, globalTags } from './tags';
 
 interface PatchUserProps {
   userId: string;
@@ -193,20 +193,18 @@ export async function deleteUser() {
       },
     });
     /* 캐시 무효화 */
-    const userTagsToInvalidate = [
-      cacheTags.me(),
-      cacheTags.publicUser(me.user_id),
-      cacheTags.follower(me.user_id),
-      cacheTags.followerList(me.user_id),
-      cacheTags.following(me.user_id),
-      cacheTags.followingList(me.user_id),
-      cacheTags.logListByUser(me.user_id),
-      cacheTags.logBookmarkList(me.user_id),
-      cacheTags.logMyList(me.user_id),
-      cacheTags.placeBookmarkList(me.user_id),
-      'search',
+    const tagsToInvalidate = [
+      globalTags.userAll,
+      globalTags.followAll,
+      globalTags.logAll,
+      globalTags.logListAll,
+      globalTags.logBookmarkAll,
+      globalTags.placeAll,
+      globalTags.placeListAll,
+      globalTags.placeBookmarkAll,
+      globalTags.searchAll,
     ];
-    userTagsToInvalidate.forEach((tag) => revalidateTag(tag));
+    tagsToInvalidate.forEach(revalidateTag);
     return { success: true, msg: ERROR_MESSAGES.USER.DELETE_SUCCESS };
   } catch (error) {
     console.error('유저 삭제 오류', error);

--- a/src/components/common/UserImage.tsx
+++ b/src/components/common/UserImage.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { cn } from '@/lib/utils';
 import { getStoragePublicImage } from '@/utils/getStorageImage';
 import Image, { ImageProps } from 'next/image';
+import { useState } from 'react';
 
 interface UserImageProps extends Omit<ImageProps, 'src' | 'alt' | 'fill'> {
   imgSrc: string | null;
@@ -15,17 +18,15 @@ function isAbsoluteUrl(url: string) {
 }
 
 export default function UserImage({ imgSrc, className, ...props }: UserImageProps) {
-  /* const finalSrc =
-    imgSrc && imgSrc !== 'null'
-      ? isBlobUrl(imgSrc) // blob URL이거나 data URL인 경우 그대로 사용
-        ? imgSrc
-        : getStoragePublicImage(imgSrc) // 일반 Supabase 경로는 변환
-      : '/profile/user-default-avatar.webp'; */
+  const [errored, setErrored] = useState(false);
+
+  const isValidImgSrc = imgSrc && imgSrc !== 'null' && imgSrc !== '';
+
   const finalSrc =
-    imgSrc && imgSrc !== 'null'
+    !errored && isValidImgSrc
       ? isBlobUrl(imgSrc) || isAbsoluteUrl(imgSrc) // 이미 절대 URL이면 그대로 사용
         ? imgSrc
-        : getStoragePublicImage(imgSrc) // Supabase 상대경로면 변환
+        : getStoragePublicImage(imgSrc) // 수파베이스 상대경로면 변환
       : '/profile/user-default-avatar.webp';
   return (
     <div
@@ -38,6 +39,7 @@ export default function UserImage({ imgSrc, className, ...props }: UserImageProp
         alt="유저 프로필 이미지"
         className="object-cover object-center"
         quality={100}
+        onError={() => setErrored(true)}
         {...props}
       />
     </div>

--- a/src/components/features/detail-log/LogAuthorIntro.tsx
+++ b/src/components/features/detail-log/LogAuthorIntro.tsx
@@ -1,13 +1,12 @@
-import { getPublicUser } from '@/app/actions/user';
+import { PublicUser } from '@/types/api/user';
 import LogProfile from './LogProfile';
 
 interface LogAuthorIntroProps {
-  userId: string;
+  user: PublicUser;
   logDescription: string;
 }
 
-const LogAuthorIntro = async ({ userId, logDescription }: LogAuthorIntroProps) => {
-  const user = await getPublicUser(userId);
+const LogAuthorIntro = ({ user, logDescription }: LogAuthorIntroProps) => {
   return (
     <div className="web:grid grid-cols-[1fr_4fr] gap-[15px] py-5 space-y-1">
       <LogProfile

--- a/src/components/features/home/LatestLogConentSection/LatestLogConent.tsx
+++ b/src/components/features/home/LatestLogConentSection/LatestLogConent.tsx
@@ -16,7 +16,7 @@ interface LatestLogConentProps {
 export default function LatestLogConent({ currentPage }: LatestLogConentProps) {
   const contentRef = useRef<HTMLElement | null>(null);
   const { handlePageChange } = useQueryPagination('logPage', currentPage, contentRef);
-  const { data } = useLogs({ currentPage, pageSize: 13 });
+  const { data } = useLogs({ currentPage, pageSize: 13, sort: 'latest' });
   if (data && !data.success) {
     throw new Error(data.msg);
   }

--- a/src/components/features/home/LatestLogConentSection/LatestLogConentSection.tsx
+++ b/src/components/features/home/LatestLogConentSection/LatestLogConentSection.tsx
@@ -12,8 +12,8 @@ export default async function LatestLogConentSection({ currentPage }: LatestLogC
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({
-    queryKey: logKeys.list({ currentPage: currentPage, pageSize: 13 }),
-    queryFn: () => getLogs({ currentPage: currentPage, pageSize: 13 }),
+    queryKey: logKeys.list({ currentPage: currentPage, pageSize: 13, sort: 'latest' }),
+    queryFn: () => getLogs({ currentPage: currentPage, pageSize: 13, sort: 'latest' }),
   });
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/MyLogs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/MyLogs.tsx
@@ -35,7 +35,7 @@ export default function MyLogs({ userId }: MyLogsProps) {
     if (!me?.user_id) return;
 
     const revalidateAndRefetch = async () => {
-      await revalidateBookmarkLogs(String(me.user_id));
+      await revalidateBookmarkLogs();
       refetch();
     };
 

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/MyLogs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/MyLogs.tsx
@@ -52,8 +52,8 @@ export default function MyLogs({ userId }: MyLogsProps) {
     <>
       <PostCardWrapper className="mb-[50px]">
         {data?.data.map((log) => (
-          <MotionCard key={log?.log_id} className="relative group">
-            <Link href={`/log/${log?.log_id}`} className="hover:cursor-default">
+          <MotionCard key={log?.log_id} className="relative group hover:cursor-default">
+            <Link href={`/log/${log?.log_id}`}>
               <PostCardImage
                 author={String(log?.users?.nickname)}
                 imageUrl={String(log?.thumbnail_url)}

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SaveLogs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SaveLogs.tsx
@@ -39,7 +39,7 @@ export default function SaveLogs({ userId }: SavaLogsProps) {
     if (!me?.user_id) return;
 
     const revalidateAndRefetch = async () => {
-      await revalidateBookmarkLogs(String(me.user_id));
+      await revalidateBookmarkLogs();
       refetch();
     };
 

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SaveLogs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SaveLogs.tsx
@@ -56,8 +56,8 @@ export default function SaveLogs({ userId }: SavaLogsProps) {
     <>
       <PostCardWrapper className="mb-[50px]">
         {data?.data.map((log) => (
-          <MotionCard key={log?.log_id} className="relative group">
-            <Link href={`/log/${log?.log_id}`} className="hover:cursor-default">
+          <MotionCard key={log?.log_id} className="relative group hover:cursor-default">
+            <Link href={`/log/${log?.log_id}`}>
               <PostCardImage
                 author={String(log?.users?.nickname)}
                 imageUrl={String(log?.thumbnail_url)}

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SavePlaces.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SavePlaces.tsx
@@ -34,7 +34,7 @@ export default function SavePlaces({ userId }: SavePlacesProps) {
     if (!me?.user_id) return;
 
     const revalidateAndRefetch = async () => {
-      await revalidateBookmarkPlaces(String(me.user_id));
+      await revalidateBookmarkPlaces();
       refetch();
     };
 

--- a/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SavePlaces.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileContent/components/SavePlaces.tsx
@@ -51,8 +51,8 @@ export default function SavePlaces({ userId }: SavePlacesProps) {
     <>
       <PostCardWrapper className="mb-[50px]">
         {data?.data.map((place) => (
-          <MotionCard key={place.place_id} className="relative group">
-            <Link href={`/log/${place.log_id}`} className="hover:cursor-default">
+          <MotionCard key={place.place_id} className="relative group hover:cursor-default">
+            <Link href={`/log/${place.log_id}`}>
               <PostCardImage author={place.user.nickname} imageUrl={place.image.image_path} />
               <PostCardTitle title={place.name} />
               <PostCardLocation category={place.category} />


### PR DESCRIPTION
## 📌 작업 주제

* SSR/CSR 쿼리 키 불일치로 인한 hydration mismatch 및 캐시 무효화 전략 개선

## 🛠 작업 내용

* **hydration mismatch 버그 수정**

  * SSR(preload)과 CSR(useLogs)에서 사용하는 쿼리 키(queryKey)가 불일치하여 hydration mismatch 발생
  * 원인: SSR에서는 `sort` 파라미터를 생략했고, CSR에서는 `'latest'`가 기본값으로 설정되어 불일치
  * 해결: SSR에서도 `sort: 'latest'`를 명시적으로 포함하여 queryKey 일치 보장

* **유저 이미지 fallback 및 오류 처리 강화**

  * 이미지 로딩 실패 시 기본 이미지로 대체되도록 `UserImage` 컴포넌트 개선
  * 회원정보 수정 실패 시 사용자에게 toast 메시지로 예외 피드백 제공

* **서버 컴포넌트 비동기 fetch 구조 개선**

  * `LogAuthorIntro`에서 직접 비동기 호출 대신 상위 컴포넌트에서 props로 주입하는 방식으로 구조 개선
  * 서버 컴포넌트 내부에서 발생하던 `undefined` 문제 해결

* **캐시 무효화 전략 전면 개편**

  * 기존의 params 기반 tag key 전략 제거 (ex. `log:list:1:10:latest` → SSR에서 hydration mismatch 원인)
  * `unstable_cache`의 `tags` 옵션에 `globalTags` 상수 적용

    * 예: `'log:list:all'`, `'place:bookmark:all'`, `'search:list:all'`
  * 사용자 삭제, 로그 삭제, 북마크 토글 등의 API에서 글로벌 태그만으로 일괄 무효화 가능하도록 개선

## 📚 추가 내용 (선택)

* `queryKey`와 `tagKey`의 구조를 통일하여 SSR과 CSR 간 데이터 일관성 확보

