### PR TITLE
SSR/CSR 캐시 무효화 전략 통일 및 홈 캐러셀 에러 처리 개선

### DIFF
--- a/src/app/(root)/profile/editor/page.tsx
+++ b/src/app/(root)/profile/editor/page.tsx
@@ -126,8 +126,8 @@ export default function ProfileEditorPage() {
       //캐시 무효화 추가
       await patchUser(updateData);
 
-      queryClient.invalidateQueries({ queryKey: userKeys.me() });
-      queryClient.invalidateQueries({ queryKey: userKeys.publicUser(String(me.user_id)) });
+      queryClient.removeQueries({ queryKey: userKeys.me(), exact: true });
+      queryClient.removeQueries({ queryKey: userKeys.publicUser(String(me.user_id)), exact: true });
 
       router.push(`/profile/${me.user_id}`);
       toast.success('회원 정보 수정 성공');

--- a/src/app/actions/log-register.ts
+++ b/src/app/actions/log-register.ts
@@ -10,7 +10,9 @@ import {
   NewTag,
 } from '@/types/schema/log';
 import { parseFormData } from '@/utils/formatLog';
+import { revalidateTag } from 'next/cache';
 import { uploadFile } from './storage';
+import { globalTags } from './tags';
 
 /* 로그 등록 */
 export async function createLog(formData: FormData) {
@@ -61,6 +63,10 @@ export async function createLog(formData: FormData) {
     console.time('🗃️ DB 삽입');
     await insertLogToDB({ logData, tagsData, placeDataList, placeImageDataList, addressData });
     console.timeEnd('🗃️ DB 삽입');
+
+    //서버 캐시 무효화
+    const tagsToInvalidate = [globalTags.logAll, globalTags.logListAll, globalTags.searchAll];
+    tagsToInvalidate.forEach((tag) => revalidateTag(tag));
 
     return { success: true, data: logId };
   } catch (e) {

--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -180,8 +180,8 @@ async function fetchLogs({
     console.error(_error);
     return {
       success: false,
-      msg: ERROR_MESSAGES.LOG.LIST_EMPTY,
-      errorCode: ERROR_CODES.LOG.LIST_EMPTY,
+      msg: ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR,
+      errorCode: ERROR_CODES.COMMON.INTERNAL_SERVER_ERROR,
     };
   }
 }

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -6,7 +6,7 @@ import { PlaceBookmarkListParmas, PlacesReseponse } from '@/types/api/place';
 import { revalidateTag, unstable_cache } from 'next/cache';
 import { prisma } from 'prisma/prisma';
 import { logKeys } from './keys';
-import { cacheTags } from './tags';
+import { cacheTags, globalTags } from './tags';
 
 // ===================================================================
 // 북마크 장소 리스트
@@ -125,5 +125,5 @@ export async function getBookmarkedPlaces(params: PlaceBookmarkListParmas) {
 
 /* 북마크 시 서버캐시 무효화 */
 export async function revalidateBookmarkPlaces() {
-  revalidateTag('place:bookmark:all');
+  revalidateTag(globalTags.placeBookmarkAll);
 }

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -107,8 +107,8 @@ export async function fetchBookmarkedPlaces({
     console.error(_error);
     return {
       success: false,
-      msg: ERROR_MESSAGES.PLACE.LIST_EMPTY,
-      errorCode: ERROR_CODES.PLACE.LIST_EMPTY,
+      msg: ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR,
+      errorCode: ERROR_CODES.COMMON.INTERNAL_SERVER_ERROR,
     };
   }
 }

--- a/src/app/actions/user.ts
+++ b/src/app/actions/user.ts
@@ -75,7 +75,7 @@ const cacheUser = unstable_cache(
   },
   [...userKeys.me()],
   {
-    tags: [cacheTags.me()],
+    tags: [cacheTags.me(), globalTags.userAll],
     revalidate: 300,
   }
 );
@@ -131,7 +131,7 @@ async function fetchPublicUser(userId: string): Promise<PublicUser | null> {
 
 export async function getPublicUser(userId: string) {
   return unstable_cache(() => fetchPublicUser(userId), [...userKeys.publicUser(userId)], {
-    tags: [cacheTags.publicUser(userId)],
+    tags: [cacheTags.publicUser(userId), globalTags.userAll],
     revalidate: 300,
   })();
 }

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -27,8 +27,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(
       {
         success: false,
-        msg: ERROR_MESSAGES.LOG.LIST_EMPTY,
-        errorCode: ERROR_CODES.LOG.LIST_EMPTY,
+        msg: ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR,
+        errorCode: ERROR_CODES.COMMON.INTERNAL_SERVER_ERROR,
       },
       { status: 500 }
     );

--- a/src/components/common/FallbackMessage.tsx
+++ b/src/components/common/FallbackMessage.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+
+interface FallbackMessage {
+  message: string;
+  className?: string;
+}
+
+export default function FallbackMessage({ message, className = '' }: FallbackMessage) {
+  return (
+    <div className={cn('flex justify-center items-start py-[49px] min-h-[350px]', className)}>
+      <h3 className="font-bold text-center text-text-sm text-primary-200">{message}</h3>
+    </div>
+  );
+}

--- a/src/components/features/detail-log/LogProfile.tsx
+++ b/src/components/features/detail-log/LogProfile.tsx
@@ -14,13 +14,22 @@ const LogProfile = async ({ userId, userImage, userNickname }: LogProfileProps) 
   const me = await getUser();
   return (
     <div className="flex items-start py-1.5">
-      <div className="flex items-center gap-4">
-        <Link href={`${PROFILE_PATHS.PROFILE}/${userId}`} className="flex items-center gap-2">
+      {userId ? (
+        <div className="flex items-center gap-4">
+          <Link href={`${PROFILE_PATHS.PROFILE}/${userId}`} className="flex items-center gap-2">
+            <UserImage imgSrc={userImage} className="w-6 h-6" />
+            <span className="text-text-sm web:text-text-md font-semibold">{userNickname}</span>
+          </Link>
+          {me && me?.user_id !== userId && <FollowingButton userId={userId} />}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
           <UserImage imgSrc={userImage} className="w-6 h-6" />
-          <span className="text-text-sm web:text-text-md font-semibold">{userNickname}</span>
-        </Link>
-        {me && me?.user_id !== userId && <FollowingButton userId={userId} />}
-      </div>
+          <span className="text-text-sm web:text-text-md font-semibold">
+            {userNickname ?? '알 수 없음'}
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/features/home/CarouselSection/CarouselContent.tsx
+++ b/src/components/features/home/CarouselSection/CarouselContent.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import FallbackMessage from '@/components/common/FallbackMessage';
+import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import useLogs from '@/hooks/queries/log/useLogs';
 import Carousel from './Carousel';
 import CarouselSkeleton from './CarouselSkeleton';
@@ -7,8 +9,19 @@ import CarouselSkeleton from './CarouselSkeleton';
 export default function CarouselContent() {
   const { data, isPending } = useLogs({ pageSize: 12, sort: 'popular' });
   if (isPending) return <CarouselSkeleton />;
-  if (data && !data?.success) {
-    throw new Error(data.msg);
+
+  if ((data && !data?.success) || data?.data.length === 0) {
+    return (
+      <FallbackMessage
+        message={
+          !data.success
+            ? ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR
+            : ERROR_MESSAGES.LOG.LIST_EMPTY
+        }
+        className="items-center"
+      />
+    );
   }
+
   return <Carousel logs={data?.data ?? []} />;
 }

--- a/src/components/features/home/LatestLogConentSection/LatestLogConent.tsx
+++ b/src/components/features/home/LatestLogConentSection/LatestLogConent.tsx
@@ -3,7 +3,9 @@
 import MotionCard from '@/components/common/Card/MotionCard';
 import { PostCard, PostCardWrapper } from '@/components/common/Card/PostCard';
 import CustomPagination from '@/components/common/CustomPagination';
+import FallbackMessage from '@/components/common/FallbackMessage';
 import { TitledSection } from '@/components/common/SectionBlock';
+import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import useLogs from '@/hooks/queries/log/useLogs';
 import useQueryPagination from '@/hooks/useQueryPagination';
 import { cn } from '@/lib/utils';
@@ -17,8 +19,18 @@ export default function LatestLogConent({ currentPage }: LatestLogConentProps) {
   const contentRef = useRef<HTMLElement | null>(null);
   const { handlePageChange } = useQueryPagination('logPage', currentPage, contentRef);
   const { data } = useLogs({ currentPage, pageSize: 13, sort: 'latest' });
-  if (data && !data.success) {
-    throw new Error(data.msg);
+
+  if ((data && !data?.success) || data?.data.length === 0) {
+    return (
+      <FallbackMessage
+        message={
+          !data.success
+            ? ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR
+            : ERROR_MESSAGES.LOG.LIST_EMPTY
+        }
+        className="items-center"
+      />
+    );
   }
   return (
     <section ref={contentRef}>

--- a/src/components/features/profile-editor/AccountDeleteSection/AccountDeleteButton.tsx
+++ b/src/components/features/profile-editor/AccountDeleteSection/AccountDeleteButton.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { followKeys, logKeys, placeKeys, searchKeys, userKeys } from '@/app/actions/keys';
 import Loading from '@/components/common/Loading/Loading';
 import { Button } from '@/components/ui/button';
 import { createClient } from '@/lib/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
 import { Dispatch, SetStateAction, useTransition } from 'react';
 import { toast } from 'sonner';
 
@@ -13,6 +15,7 @@ interface AccountDeleteButtonProps {
 
 export default function AccountDeleteButton({ setIsSuccess, setMsg }: AccountDeleteButtonProps) {
   const [isPending, startTransition] = useTransition();
+  const queryClient = useQueryClient();
 
   const handleDelete = () => {
     if (isPending) return;
@@ -24,10 +27,24 @@ export default function AccountDeleteButton({ setIsSuccess, setMsg }: AccountDel
       if (result.success) {
         const supabase = createClient();
         await supabase.auth.signOut(); // 쿠키 삭제
+
+        const keysToRemove = [
+          userKeys.all,
+          followKeys.all,
+          logKeys.log,
+          placeKeys.place,
+          searchKeys.all,
+        ];
+        keysToRemove.forEach((key) => {
+          queryClient.removeQueries({ queryKey: key, exact: false });
+        });
+
         setIsSuccess(true);
+        toast.success('계정 삭제 성공');
+      } else {
+        toast.error('계정 삭제 실패');
       }
       setMsg(result.msg);
-      toast.success('계정 삭제 성공');
     });
   };
   return (

--- a/src/hooks/mutations/log/useLogCreateMutation.ts
+++ b/src/hooks/mutations/log/useLogCreateMutation.ts
@@ -1,6 +1,7 @@
+import { logKeys, searchKeys } from '@/app/actions/keys';
 import { createLog } from '@/app/actions/log-register';
 import { useLogCreationStore } from '@/stores/logCreationStore';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
@@ -10,12 +11,20 @@ interface LogCreateMutationProps {
 
 const useLogCreateMutation = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const clearTag = useLogCreationStore((state) => state.clearTag);
   return useMutation({
     mutationFn: ({ formData }: LogCreateMutationProps) => createLog(formData),
     onSuccess: ({ success, data }) => {
       if (success) {
         clearTag();
+
+        const keysToInvalidate = [logKeys.log, searchKeys.all];
+
+        keysToInvalidate.forEach((key) =>
+          queryClient.removeQueries({ queryKey: key, exact: false })
+        );
+
         router.replace(`/log/${data}`);
         toast.success('업로드 성공');
       }

--- a/src/hooks/mutations/log/useLogDeleteMutation.ts
+++ b/src/hooks/mutations/log/useLogDeleteMutation.ts
@@ -20,7 +20,7 @@ const useLogDeleteMutation = () => {
         const keysToInvalidate = [logKeys.log, placeKeys.place, searchKeys.all];
 
         keysToInvalidate.forEach((key) => {
-          queryClient.invalidateQueries({ queryKey: key });
+          queryClient.removeQueries({ queryKey: key, exact: false });
         });
         router.replace(HOME);
       }

--- a/src/hooks/mutations/log/useLogEditMutation.ts
+++ b/src/hooks/mutations/log/useLogEditMutation.ts
@@ -1,6 +1,7 @@
+import { logKeys, placeKeys, searchKeys } from '@/app/actions/keys';
 import { updateLog } from '@/app/actions/log-update';
 import { useLogCreationStore } from '@/stores/logCreationStore';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
@@ -11,12 +12,20 @@ interface LogEditMutationProps {
 
 const useLogEditMutation = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const clearTag = useLogCreationStore((state) => state.clearTag);
   return useMutation({
     mutationFn: ({ formData, logId }: LogEditMutationProps) => updateLog(formData, logId),
     onSuccess: ({ success }, { logId }) => {
       if (success) {
         clearTag();
+
+        const keysToInvalidate = [logKeys.log, placeKeys.place, searchKeys.all];
+
+        keysToInvalidate.forEach((key) => {
+          queryClient.removeQueries({ queryKey: key, exact: false });
+        });
+
         router.replace(`/log/${logId}`);
         toast.success('로그 수정 성공');
       }


### PR DESCRIPTION
## 📌 작업 주제

* 홈 캐러셀 에러 핸들링 개선 및 캐시 무효화 전략 통일
* 유저 정보 미존재 시 UI 조건 분기 강화

## 🛠 작업 내용

* **홈 캐러셀 에러 처리 개선**

  * 기존에는 `/` 홈에서 로그 데이터 요청 실패 시 `error.tsx`로 에러를 던져 무한 루프 발생
  * 서버 에러 또는 빈 응답 시 `FallbackMessage`를 렌더링하도록 변경하여 UX 개선

* **정보 수정 시 SSR/CSR 캐시 무효화 범위 일치**

  * 수정 이벤트 발생 시 태그키와 캐시키의 무효화 기준을 완전 통일하여 hydration mismatch 방지

* **상세 페이지에서 `userId` 미존재 시 UI 보호**

  * 유저 데이터가 `undefined`일 경우, 프로필 링크 및 팔로우 버튼 렌더링 제거
  * `Link` 대신 단순 텍스트만 표시하여 예상치 못한 에러 예방

