### PR TITLE
유효하지 않은 접근 시 404 처리 및 드롭다운 UX 개선

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -393,7 +393,7 @@ model place {
   category       String
   updated_at     DateTime?        @db.Timestamptz(6)
   place_id       String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  order          BigInt
+  order          Int
   log_id         String?          @db.Uuid
   log            log?             @relation(fields: [log_id], references: [log_id], onDelete: Cascade, onUpdate: NoAction)
   place_bookmark place_bookmark[]

--- a/src/app/(root)/log/[logId]/not-found.tsx
+++ b/src/app/(root)/log/[logId]/not-found.tsx
@@ -1,0 +1,5 @@
+import ErrorTemplate from '@/components/common/ErrorTemplate';
+
+export default function NotFound() {
+  return <ErrorTemplate message="존재하지 않는 로그입니다." />;
+}

--- a/src/app/(root)/log/[logId]/page.tsx
+++ b/src/app/(root)/log/[logId]/page.tsx
@@ -8,6 +8,7 @@ import LogContent from '@/components/features/detail-log/LogContent';
 import LogThubmnail from '@/components/features/detail-log/LogThubmnail';
 import { PlaceWithImages } from '@/types/api/log';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
 export interface LogIdParams {
   logId: string;
@@ -20,7 +21,7 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
   const { logId } = await params;
   const result = await fetchLog(logId);
   if (!result.success) {
-    throw new Error(result.msg);
+    notFound();
   }
   const { data: logData } = result;
   const user = await getUser();

--- a/src/app/(root)/profile/[userId]/not-found.tsx
+++ b/src/app/(root)/profile/[userId]/not-found.tsx
@@ -1,0 +1,5 @@
+import ErrorTemplate from '@/components/common/ErrorTemplate';
+
+export default function NotFound() {
+  return <ErrorTemplate message="존재하지 않는 유저입니다." />;
+}

--- a/src/app/(root)/profile/[userId]/page.tsx
+++ b/src/app/(root)/profile/[userId]/page.tsx
@@ -1,6 +1,7 @@
 import { getPublicUser, getUser } from '@/app/actions/user';
 import ProfileHeader from '@/components/features/profile/ProfileHeader/ProfileHeader';
 import ProfileTabSection from '@/components/features/profile/ProfileTabContent/ProfileTabSection';
+import { notFound } from 'next/navigation';
 
 interface ProfilepageProps {
   params: Promise<{ userId: string }>;
@@ -14,7 +15,7 @@ export default async function Page({ params }: ProfilepageProps) {
   const user = isMe ? me : await getPublicUser(userId);
 
   if (!user) {
-    throw new Error('존재하지 않는 유저입니다.');
+    notFound();
   }
   return (
     <main className="pt-7.5 web:pt-15 mx-4 web:mx-12.5 mb-35 web:mb-25">

--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -39,9 +39,11 @@ export async function fetchLog(logId: string): Promise<ApiResponse<DetailLog>> {
       )
       .order('order', { referencedTable: 'place', ascending: true })
       .eq('log_id', logId)
-      .single(); */
+      .single();
 
-    /* if (!data || error?.code === 'PGRST116') {
+    console.log('data', data);
+
+    if (!data || error?.code === 'PGRST116') {
       return {
         success: false,
         msg: ERROR_MESSAGES.LOG.NOT_FOUND,

--- a/src/components/common/ErrorTemplate.tsx
+++ b/src/components/common/ErrorTemplate.tsx
@@ -21,7 +21,7 @@ export default function ErrorTemplate({
   return (
     <main className="flex flex-col items-center justify-center h-dvh grow">
       <Image src={ErrorImg} alt="notFound 이미지" priority />
-      <div className="flex flex-col mt-[50px] mb-5">
+      <div className="flex flex-col items-center mt-[50px] mb-5">
         <h4 className="text-text-xl font-bold">{title}</h4>
         <h5 className="text-center">{message}</h5>
       </div>

--- a/src/components/common/Header/Header/components/UserProfileButton/UserProfileButton.tsx
+++ b/src/components/common/Header/Header/components/UserProfileButton/UserProfileButton.tsx
@@ -21,13 +21,15 @@ interface UserProfileButtonProps {
 
 export default function UserProfileButton({ user }: UserProfileButtonProps) {
   const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+
   useEffect(() => {
     setMounted(true);
   }, []);
 
   if (!mounted) return null;
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
       <DropdownMenuTrigger className="focus:outline-none" asChild>
         <Button variant={'ghost'} size={'icon'} className="relative group">
           <UserIcon className="absolute group-hover:opacity-0" />
@@ -45,7 +47,7 @@ export default function UserProfileButton({ user }: UserProfileButtonProps) {
           {/* {!isTruncated && <VerifiedLabelIcon />} */}
         </DropdownMenuItem>
         <DropdownMenuItem className="px-4 py-5 focus:bg-white">
-          <MyProfileButton user={user} />
+          <MyProfileButton user={user} onClick={() => setOpen(false)} />
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <div className="m-1">

--- a/src/components/common/Header/Header/components/UserProfileButton/components/MyProfileButton.tsx
+++ b/src/components/common/Header/Header/components/UserProfileButton/components/MyProfileButton.tsx
@@ -6,12 +6,16 @@ import Link from 'next/link';
 
 interface MyProfileButtonProps {
   user: IUser;
+  onClick?: () => void;
 }
 
-export default function MyProfileButton({ user }: MyProfileButtonProps) {
+export default function MyProfileButton({ user, onClick }: MyProfileButtonProps) {
   return (
-    <Link href={`/profile/${user?.user_id}`} className="w-full">
-      <Button disabled={!user} className="w-full h-full rounded-[60px] bg-[#F7F7F7] hover:bg-[#F7F7F7]">
+    <Link href={`/profile/${user?.user_id}`} onClick={onClick} className="w-full">
+      <Button
+        disabled={!user}
+        className="w-full h-full rounded-[60px] bg-[#F7F7F7] hover:bg-[#F7F7F7]"
+      >
         <span className="font-medium text-black text-text-sm">프로필 보기</span>
       </Button>
     </Link>


### PR DESCRIPTION
## 📌 작업 주제

- 유효하지 않은 유저/로그 접근 시 404 페이지로 전환
- 프로필 드롭다운 내 "프로필 보기" 버튼 클릭 시 드롭다운 자동 닫힘 처리

## 🛠 작업 내용

- 유저 상세 페이지에서 존재하지 않는 유저 ID로 접근 시 `throw` 대신 `notFound()` 사용
- 로그 상세 페이지에서도 존재하지 않는 logId 접근 시 `notFound()`로 라우팅
- 각 페이지별 route segment에 맞는 `not-found.tsx` 생성하여 커스텀 404 UI 적용
- 프로덕션 환경에서 `throw new Error()`로 발생한 에러 메시지가 숨겨지는 문제 방지
- "프로필 보기" 버튼 클릭 시 드롭다운 메뉴 닫히도록 개선

## 📚 추가 내용 (선택)

- `ErrorTemplate`를 재활용하여 404 UI의 일관성 유지
