### PR TITLE
상세 페이지 북마크 수 UI 개선 및 낙관적 업데이트 구현

### DIFF
--- a/src/app/(root)/log/[logId]/page.tsx
+++ b/src/app/(root)/log/[logId]/page.tsx
@@ -1,9 +1,9 @@
 import { fetchLog } from '@/app/actions/log';
 import { getUser } from '@/app/actions/user';
-import LogBookMarkButton from '@/components/common/Button/Bookmark/LogBookMarkButton';
 import { PenBlackIcon, TableIcon } from '@/components/common/Icons';
 import ExtraActionButton from '@/components/features/detail-log/ExtraActionButton';
 import LogAuthorIntro from '@/components/features/detail-log/LogAuthorIntro';
+import LogBookmarkWithCount from '@/components/features/detail-log/LogBookmarkWithCount';
 import LogContent from '@/components/features/detail-log/LogContent';
 import LogThubmnail from '@/components/features/detail-log/LogThubmnail';
 import { PlaceWithImages } from '@/types/api/log';
@@ -48,12 +48,10 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
             </Link>
           </ExtraActionButton>
         ) : (
-          <ExtraActionButton className="w-11 h-11" asChild>
-            <LogBookMarkButton
-              logId={logData.log_id}
-              className="rounded-full relative !top-0 !right-0"
-            />
-          </ExtraActionButton>
+          <LogBookmarkWithCount
+            logId={logData.log_id}
+            initialCount={logData._count?.log_bookmark ?? 0}
+          />
         )}
         <ExtraActionButton className="w-11 h-11" asChild>
           <Link href={`/log/${logData.log_id}/placeCollect`}>

--- a/src/app/(root)/log/[logId]/page.tsx
+++ b/src/app/(root)/log/[logId]/page.tsx
@@ -40,7 +40,7 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
           <LogContent key={place.place_id} place={place} idx={idx + 1} />
         ))}
       </main>
-      <div className="flex flex-col gap-2 fixed z-10 bottom-10 web:right-[50px] right-4">
+      <div className="flex flex-col items-center gap-2 fixed z-10 bottom-10 web:right-[50px] right-4">
         {isAuthor ? (
           <ExtraActionButton className="w-11 h-11">
             <Link href={`/${logData.log_id}/edit`}>

--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -63,6 +63,7 @@ export async function fetchLog(logId: string): Promise<ApiResponse<DetailLog>> {
         place: {
           include: {
             place_images: true,
+            _count: { select: { place_bookmark: true } },
           },
           orderBy: {
             order: 'asc',
@@ -81,6 +82,7 @@ export async function fetchLog(logId: string): Promise<ApiResponse<DetailLog>> {
             sigungu: true,
           },
         },
+        _count: { select: { log_bookmark: true } },
       },
     });
 

--- a/src/components/common/Button/Bookmark/LogBookMarkButton.tsx
+++ b/src/components/common/Button/Bookmark/LogBookMarkButton.tsx
@@ -10,18 +10,25 @@ interface LogBookMarkButtonProps {
   logId: string;
   modal?: boolean;
   className?: string;
+  onToggle?: (isBookmarked: boolean) => void;
 }
 
-export default function LogBookMarkButton({ logId, modal, className }: LogBookMarkButtonProps) {
+export default function LogBookMarkButton({
+  logId,
+  modal,
+  className,
+  onToggle,
+}: LogBookMarkButtonProps) {
   const router = useRouter();
   const { data: user, isLoading: userIsLoading } = useUser();
   const { data, isLoading } = useLogBookmarkCheck({ logId, userId: user?.user_id || null });
-  const { mutate } = useLogBookmarkMutation();
+  const { mutate } = useLogBookmarkMutation(onToggle);
 
   const onBookMarkClick = () => {
     if (userIsLoading) return;
     if (!user) {
       router.push('/login');
+      return;
     }
     if (!data) return;
     mutate({ logId, isBookmark: data.isBookmark });

--- a/src/components/common/Button/Bookmark/PlaceBookMarkButton.tsx
+++ b/src/components/common/Button/Bookmark/PlaceBookMarkButton.tsx
@@ -10,22 +10,25 @@ interface PlaceBookMarkButtonProps {
   placeId: string;
   modal?: boolean;
   className?: string;
+  onToggle?: (isBookmarked: boolean) => void;
 }
 
 export default function PlaceBookMarkButton({
   placeId,
   modal,
   className,
+  onToggle,
 }: PlaceBookMarkButtonProps) {
   const router = useRouter();
   const { data: user, isLoading: userIsLoading } = useUser();
   const { data, isLoading } = usePlaceBookmarkCheck({ placeId, userId: user?.user_id || null });
-  const { mutate } = usePlaceBookmarkMutation();
+  const { mutate } = usePlaceBookmarkMutation(onToggle);
 
   const onBookMarkClick = () => {
     if (userIsLoading) return;
     if (!user) {
       router.push('/login');
+      return;
     }
     if (!data) return;
     mutate({

--- a/src/components/common/Header/Header/Header.tsx
+++ b/src/components/common/Header/Header/Header.tsx
@@ -10,7 +10,7 @@ import ClientOnlyLoginStatusButtons from './components/UserProfileButton/ClientO
 const Header = async () => {
   const user = await getUser();
   return (
-    <header className="flex items-center justify-between sticky w-full z-50 bg-black px-4 web:px-[50px] py-4 web:py-5 left-0 top-0 web:h-[60px] h-12">
+    <header className="flex items-center justify-between fixed w-full z-50 bg-black px-4 web:px-[50px] py-4 web:py-5 left-0 top-0 web:h-[60px] h-12">
       <Logo />
       <section className="flex items-center text-white web:gap-11">
         <SearchBarButton />

--- a/src/components/features/detail-log/LogBookmarkWithCount.tsx
+++ b/src/components/features/detail-log/LogBookmarkWithCount.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import LogBookMarkButton from '@/components/common/Button/Bookmark/LogBookMarkButton';
+import { formatCount } from '@/lib/utils';
 import { useState } from 'react';
 import ExtraActionButton from './ExtraActionButton';
 
@@ -19,7 +20,7 @@ export default function LogBookmarkWithCount({ logId, initialCount }: LogBookmar
   return (
     <section className="flex flex-col items-center gap-1.5">
       <div className="w-13 h-6.5 px-1.5 bg-black rounded-[999px] flex justify-center items-center border-2 border-white">
-        <span className="text-white text-text-lg font-bold">{bookmarkCount}</span>
+        <span className="text-white text-text-lg font-bold">{formatCount(bookmarkCount)}</span>
       </div>
       <ExtraActionButton className="w-11 h-11" asChild>
         <div className="flex flex-col">

--- a/src/components/features/detail-log/LogBookmarkWithCount.tsx
+++ b/src/components/features/detail-log/LogBookmarkWithCount.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import LogBookMarkButton from '@/components/common/Button/Bookmark/LogBookMarkButton';
+import { useState } from 'react';
+import ExtraActionButton from './ExtraActionButton';
+
+interface LogBookmarkWithCountProps {
+  logId: string;
+  initialCount: number;
+}
+
+export default function LogBookmarkWithCount({ logId, initialCount }: LogBookmarkWithCountProps) {
+  const [bookmarkCount, setBookmarkCount] = useState(initialCount);
+
+  const handleToggle = (newStatus: boolean) => {
+    setBookmarkCount((prev) => prev + (newStatus ? 1 : -1));
+  };
+
+  return (
+    <section className="flex flex-col items-center gap-1.5">
+      <div className="w-13 h-6.5 px-1.5 bg-black rounded-[999px] flex justify-center items-center border-2 border-white">
+        <span className="text-white text-text-lg font-bold">{bookmarkCount}</span>
+      </div>
+      <ExtraActionButton className="w-11 h-11" asChild>
+        <div className="flex flex-col">
+          <LogBookMarkButton
+            logId={logId}
+            onToggle={handleToggle}
+            className="rounded-full relative !top-0 !right-0"
+          />
+        </div>
+      </ExtraActionButton>
+    </section>
+  );
+}

--- a/src/components/features/detail-log/LogContent.tsx
+++ b/src/components/features/detail-log/LogContent.tsx
@@ -2,6 +2,7 @@
 
 import PlaceBookMarkButton from '@/components/common/Button/Bookmark/PlaceBookMarkButton';
 import { ClockIcon, LocationIcon } from '@/components/common/Icons';
+import { formatCount } from '@/lib/utils';
 import { DetailLog } from '@/types/api/log';
 import { useState } from 'react';
 import PlaceImageSlider from './PlaceImageSlider';
@@ -30,7 +31,9 @@ const LogContent = ({ place, idx }: LogContentProps) => {
               onToggle={handleToggleBookmark}
               className="!top-0 !right-0 !relative"
             />
-            <span className="font-medium text-text-sm text-light-300">{bookmarkCount}</span>
+            <span className="font-medium text-text-sm text-light-300">
+              {formatCount(bookmarkCount)}
+            </span>
           </section>
         </div>
         <div>

--- a/src/components/features/detail-log/LogContent.tsx
+++ b/src/components/features/detail-log/LogContent.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import PlaceBookMarkButton from '@/components/common/Button/Bookmark/PlaceBookMarkButton';
 import { ClockIcon, LocationIcon } from '@/components/common/Icons';
 import { DetailLog } from '@/types/api/log';
+import { useState } from 'react';
 import PlaceImageSlider from './PlaceImageSlider';
 
 interface LogContentProps {
@@ -9,6 +12,10 @@ interface LogContentProps {
 }
 
 const LogContent = ({ place, idx }: LogContentProps) => {
+  const [bookmarkCount, setBookmarkCount] = useState(place._count?.place_bookmark ?? 0);
+  const handleToggleBookmark = (newStatus: boolean) => {
+    setBookmarkCount((prev) => prev + (newStatus ? 1 : -1));
+  };
   return (
     <div className="web:grid grid-cols-[1fr_4fr] gap-[15px] border-t pt-[15px] web:pt-3 py-10 space-y-[15px]">
       <section className="flex flex-col gap-2 relative">
@@ -17,7 +24,14 @@ const LogContent = ({ place, idx }: LogContentProps) => {
             <span>{String(idx).padStart(2, '0')}</span>
             <span>{place.name}</span>
           </div>
-          <PlaceBookMarkButton placeId={place.place_id} className="!top-0 !right-0" />
+          <section className="absolute top-0 right-0 flex flex-col items-center">
+            <PlaceBookMarkButton
+              placeId={place.place_id}
+              onToggle={handleToggleBookmark}
+              className="!top-0 !right-0 !relative"
+            />
+            <span className="font-medium text-text-sm text-light-300">{bookmarkCount}</span>
+          </section>
         </div>
         <div>
           <div className="flex gap-1.5 text-light-400 text-text-sm web:text-text-lg">

--- a/src/components/features/detail-log/LogContent.tsx
+++ b/src/components/features/detail-log/LogContent.tsx
@@ -36,14 +36,14 @@ const LogContent = ({ place, idx }: LogContentProps) => {
             </span>
           </section>
         </div>
-        <div>
-          <div className="flex gap-1.5 text-light-400 text-text-sm web:text-text-lg">
-            <ClockIcon />
-            <span>{place.category}</span>
+        <div className="web:max-w-[324px] flex flex-col gap-2">
+          <div className="flex items-start gap-1.5 text-light-400 text-text-sm web:text-text-lg">
+            <ClockIcon className="mt-0.5 flex-shrink-0" />
+            <span className="break-words block min-w-0">{place.category}</span>
           </div>
-          <div className="flex gap-1.5 text-light-400 text-text-sm web:text-text-lg">
-            <LocationIcon />
-            <span>{place.address}</span>
+          <div className="flex items-start gap-1.5 text-light-400 text-text-sm web:text-text-lg">
+            <LocationIcon className="mt-0.5 flex-shrink-0" />
+            <span className="break-words block min-w-0">{place.address}</span>
           </div>
         </div>
       </section>

--- a/src/components/features/home/CarouselSection/Carousel.tsx
+++ b/src/components/features/home/CarouselSection/Carousel.tsx
@@ -41,6 +41,8 @@ const Carousel = ({ logs }: { logs: LogWithUserAndAddress[] }) => {
         />
       </span>
       <Swiper
+        simulateTouch={true} // 기본값이긴 하지만 명시적으로 넣어주는 것도 좋음
+        touchStartPreventDefault={false} // 트랙패드 스크롤을 막지 않도록 설정
         watchSlidesProgress
         modules={[Autoplay, Pagination]}
         autoplay={{ delay: 3000 }}

--- a/src/components/features/profile/ProfileHeader/ProfileHeader.tsx
+++ b/src/components/features/profile/ProfileHeader/ProfileHeader.tsx
@@ -38,7 +38,7 @@ export default function ProfileHeader({ me, user, isMe }: ProfileHeaderProps) {
             </>
           )}
         </h3>
-        <h3>{user?.insta_id ? user?.insta_id : '@spoteditorofficial'}</h3>
+        <h3>{user?.insta_id || ''}</h3>
       </section>
       <ProfileActionButton
         me={me}

--- a/src/hooks/mutations/log/useLogBookmarkMutation.ts
+++ b/src/hooks/mutations/log/useLogBookmarkMutation.ts
@@ -14,7 +14,8 @@ async function fetchLogBookmark({
   const data = await res.json();
   return data;
 }
-export default function useLogBookmarkMutation() {
+
+export default function useLogBookmarkMutation(onToggle?: (newStatus: boolean) => void) {
   const { data: user } = useUser();
   const queryClient = useQueryClient();
 
@@ -37,6 +38,9 @@ export default function useLogBookmarkMutation() {
         })
       );
 
+      // 상세페이지 카운트 반영
+      onToggle?.(!isBookmark);
+
       return { previousbookmarkStatus };
     },
     onError: (_error, variables, context) => {
@@ -46,6 +50,8 @@ export default function useLogBookmarkMutation() {
           context.previousbookmarkStatus
         );
       }
+      // 상세페이지 롤백 시 카운트도 복구
+      onToggle?.(variables.isBookmark);
     },
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({

--- a/src/hooks/mutations/place/usePlaceBookmarkMutation.ts
+++ b/src/hooks/mutations/place/usePlaceBookmarkMutation.ts
@@ -15,7 +15,7 @@ async function fetchPlaceBookmark({
   return data;
 }
 
-export default function usePlaceBookmarkMutation() {
+export default function usePlaceBookmarkMutation(onToggle?: (newStatus: boolean) => void) {
   const { data: user } = useUser();
   const queryClient = useQueryClient();
 
@@ -38,6 +38,9 @@ export default function usePlaceBookmarkMutation() {
         })
       );
 
+      // 상세페이지 카운트 반영
+      onToggle?.(!isBookmark);
+
       return { previousData };
     },
     onError: (_error, variables, context) => {
@@ -47,6 +50,9 @@ export default function usePlaceBookmarkMutation() {
           context.previousData
         );
       }
+
+      // 상세페이지 롤백 시 카운트도 복구
+      onToggle?.(variables.isBookmark);
     },
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -76,3 +76,14 @@ export async function uploadToSignedUrl(
 
   return res.ok;
 }
+
+/* 숫자를 K(천), M(백만) 단위로 축약하여 표시하는 함수 */
+export function formatCount(count: number): string {
+  if (count >= 1_000_000) {
+    return (count / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+  }
+  if (count >= 1_000) {
+    return (count / 1_000).toFixed(1).replace(/\.0$/, '') + 'K';
+  }
+  return count.toString();
+}

--- a/src/types/api/log.d.ts
+++ b/src/types/api/log.d.ts
@@ -4,6 +4,9 @@ import { ApiResponse, LogWithUserAndAddress, PaginationParams } from './common';
 /* 로그 */
 type PlaceWithImages = Tables<'place'> & {
   place_images: Tables<'place_images'>[];
+  _count?: {
+    place_bookmark: number;
+  };
 };
 
 export type DetailLog = Tables<'log'> & {
@@ -12,6 +15,7 @@ export type DetailLog = Tables<'log'> & {
   log_tag: Array<Pick<Tables<'log_tag'>, 'category' | 'tag'>>;
   address: Array<Pick<Tables<'address'>, 'country' | 'city' | 'sigungu'>>;
   users: Pick<Tables<'users'>, 'image_url' | 'nickname'>;
+  _count?: { log_bookmark: number };
 };
 
 /* 로그리스트 */


### PR DESCRIPTION
## 📌 작업 주제

상세 페이지에서 장소 및 로그 북마크 수 UI 개선 및 낙관적 업데이트 구현

## 🛠 작업 내용

* **장소 상세 페이지**

  * 장소별 북마크 수를 표시하는 UI 추가
  * `PlaceBookMarkButton`에 `onToggle` 콜백 추가로 낙관적 카운트 반영
  * `usePlaceBookmarkMutation`에서 `onMutate`를 활용한 캐시 선반영 처리

* **로그 상세 페이지**

  * 로그 북마크 버튼 및 북마크 수 표시 기능 추가
  * `useLogBookmarkMutation`에 `onToggle` 콜백 추가로 낙관적 카운트 반영

* **공통 기능**

  * 북마크 수를 `K/M` 단위로 표시하는 `formatCount` 유틸 함수 추가

* **UI 개선**

  * 장소 정보 영역에서 긴 텍스트가 박스를 벗어나지 않도록 스타일 수정
  → span에 min-w-0을 줘서 텍스트가 flex-item으로 인식될 때 줄바꿈이 가능하게 설정
  → 아이콘에 flex-shrink-0을 줘서 줄바꿈 시 아이콘 크기가 줄어들지 않게 고정
  * 프로필 화면에서 기본 인스타 아이디 fallback 제거
  * 트랙패드에서 캐러셀 드래그 안되는 문제 수정
  * 스크롤 시 헤더 항상 상단에 고정

