### PR TITLE
로그인 모달 및 UI 요소 스타일 조정

### DIFF
--- a/public/icons/bookmark.svg
+++ b/public/icons/bookmark.svg
@@ -1,3 +1,0 @@
-<svg width="22" height="29" viewBox="0 0 22 29" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M20.25 1.75V26.5742L11.7256 20.5029L11 19.9863L10.2744 20.5029L1.75 26.5742V1.75H20.25Z" stroke="black" stroke-width="2.5"/>
-</svg>

--- a/src/app/(root)/@modal/(.)login/page.tsx
+++ b/src/app/(root)/@modal/(.)login/page.tsx
@@ -10,9 +10,9 @@ export default function LoginModal() {
       <ModalHeader>
         <XButton />
       </ModalHeader>
-      <section className="flex flex-col text-center items-center gap-6 self-stretch">
-        <h1 className="font-prompt text-3xl font-bold">Spoteditor</h1>
-        <h2 className="font-bold text-2xl">로그인</h2>
+      <section className="flex flex-col text-center items-center self-stretch">
+        <h1 className="font-prompt text-3xl font-bold mb-10">Spoteditor</h1>
+        <h2 className="font-bold text-lg web:text-xl mb-3">로그인</h2>
         <p className="text-center text-text-sm text-light-700">
           지금 로그인 하시고 매일 새로운 Spoteditor의
           <br /> 업데이트 소식을 확인해보세요.

--- a/src/components/common/Button/Bookmark/LogBookMarkButton.tsx
+++ b/src/components/common/Button/Bookmark/LogBookMarkButton.tsx
@@ -1,9 +1,9 @@
 'use client';
+import { BookMarkIcon } from '@/components/common/Icons';
 import useLogBookmarkMutation from '@/hooks/mutations/log/useLogBookmarkMutation';
 import useLogBookmarkCheck from '@/hooks/queries/log/useLogBookmarkCheck';
 import useUser from '@/hooks/queries/user/useUser';
 import { cn } from '@/lib/utils';
-import { Bookmark } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface LogBookMarkButtonProps {
@@ -43,7 +43,7 @@ export default function LogBookMarkButton({
         className
       )}
     >
-      <Bookmark className={cn('!w-6 !h-6', data?.isBookmark && 'fill-black')} />
+      <BookMarkIcon className={cn('w-6 h-6', data?.isBookmark && 'fill-black')} />
     </button>
   );
 }

--- a/src/components/common/Button/Bookmark/PlaceBookMarkButton.tsx
+++ b/src/components/common/Button/Bookmark/PlaceBookMarkButton.tsx
@@ -1,9 +1,9 @@
 'use client';
+import { BookMarkIcon } from '@/components/common/Icons';
 import usePlaceBookmarkMutation from '@/hooks/mutations/place/usePlaceBookmarkMutation';
 import usePlaceBookmarkCheck from '@/hooks/queries/place/useIsPlaceBookmarkCheck';
 import useUser from '@/hooks/queries/user/useUser';
 import { cn } from '@/lib/utils';
-import { Bookmark } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 interface PlaceBookMarkButtonProps {
@@ -46,7 +46,7 @@ export default function PlaceBookMarkButton({
         className
       )}
     >
-      <Bookmark className={cn('!w-6 !h-6', data?.isBookmark && 'fill-black')} />
+      <BookMarkIcon className={cn('w-6 h-6', data?.isBookmark && 'fill-black')} />
     </button>
   );
 }

--- a/src/components/common/Button/XButton.tsx
+++ b/src/components/common/Button/XButton.tsx
@@ -7,7 +7,7 @@ export default function XButton() {
   const router = useRouter();
   return (
     <button className="hover:cursor-pointer" onClick={() => router.back()}>
-      <XIcon />
+      <XIcon className="w-3 h-3" />
     </button>
   );
 }

--- a/src/components/common/Icons/index.tsx
+++ b/src/components/common/Icons/index.tsx
@@ -216,13 +216,20 @@ export const TableIcon = ({ className }: IconProps) => {
 };
 export const BookMarkIcon = ({ className }: IconProps) => {
   return (
-    <Image
-      src="/icons/bookmark.svg"
-      width={20}
-      height={20}
-      alt="북마크 아이콘"
-      className={className}
-    />
+    <svg
+      width="18"
+      height="22"
+      viewBox="0 0 18 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn('w-4.5 h-5.5', className)}
+    >
+      <path
+        d="M16.1665 1.02344V20.25L9.58057 15.5586L9.00049 15.1455L8.42041 15.5586L1.8335 20.25V1.02344H16.1665Z"
+        stroke="black"
+        strokeWidth="2"
+      />
+    </svg>
   );
 };
 export const ShareIcon = ({ className }: IconProps) => {

--- a/src/components/features/detail-log/LogContent.tsx
+++ b/src/components/features/detail-log/LogContent.tsx
@@ -36,7 +36,7 @@ const LogContent = ({ place, idx }: LogContentProps) => {
             </span>
           </section>
         </div>
-        <div>
+        <div className="flex flex-col gap-[3px]">
           <div className="flex gap-1.5 text-light-400 text-text-sm web:text-text-lg">
             <MapIcon />
             <span>{place.category}</span>

--- a/src/components/features/detail-log/LogContent.tsx
+++ b/src/components/features/detail-log/LogContent.tsx
@@ -29,20 +29,20 @@ const LogContent = ({ place, idx }: LogContentProps) => {
             <PlaceBookMarkButton
               placeId={place.place_id}
               onToggle={handleToggleBookmark}
-              className="!top-0 !right-0 !relative"
+              className="!top-0 !right-0 !relative w-9 h-9"
             />
             <span className="font-medium text-text-sm text-light-300">
               {formatCount(bookmarkCount)}
             </span>
           </section>
         </div>
-        <div className="flex flex-col gap-[3px]">
+        <div className="flex flex-col web:w-[324px] gap-[2px]">
           <div className="flex gap-1.5 text-light-400 text-text-sm web:text-text-lg">
-            <MapIcon />
-            <span>{place.category}</span>
+            <MapIcon className="w-4.5 h-4.5 mt-1" />
+            <span className="break-words block min-w-0">{place.category}</span>
           </div>
           <div className="flex items-start gap-1.5 text-light-400 text-text-sm web:text-text-lg">
-            <LocationIcon className="mt-0.5 flex-shrink-0" />
+            <LocationIcon className="w-4.5 h-4.5 mt-1 flex-shrink-0" />
             <span className="break-words block min-w-0">{place.address}</span>
           </div>
         </div>

--- a/src/components/features/home/CitySearchForm/CitySearchForm.tsx
+++ b/src/components/features/home/CitySearchForm/CitySearchForm.tsx
@@ -62,7 +62,7 @@ export default function CitySearchForm() {
           onSubmit={form.handleSubmit(onSearchSubmit)}
           className="flex flex-col gap-2.5 web:grid web:grid-cols-[3fr_70px] relative bottom-0 web:z-30"
         >
-          <div className="grid grid-cols-2 gap-1.5">
+          <div className="grid grid-cols-2 gap-2.5">
             <FormField
               control={form.control}
               name="city"

--- a/src/components/features/home/CitySearchForm/SearchDropBox/SearchDropBox.tsx
+++ b/src/components/features/home/CitySearchForm/SearchDropBox/SearchDropBox.tsx
@@ -49,7 +49,7 @@ export default function SearchDropBox() {
     <AnimatePresence>
       {isDropBox ? (
         <motion.section
-          className="z-[1111] web:z-10 fixed overflow-hidden web:absolute top-0 web:top-[93px] left-0 web:left-auto bg-white w-screen h-screen web:h-auto web:max-w-[calc(100%)] px-4 web:py-5 web:pl-[30px] web:pr-5 flex flex-col gap-[18px] web:gap-2.5"
+          className="z-[1111] web:z-10 fixed overflow-hidden web:absolute top-0 web:top-[107px] left-0 web:left-auto bg-white w-screen h-screen web:h-auto web:max-w-[calc(100%)] px-4 web:py-5 web:pl-[30px] web:pr-5 flex flex-col gap-[18px] web:gap-2.5"
           key="dropbox"
           variants={dropboxVar}
           initial="start"


### PR DESCRIPTION
## 📌 작업 주제

 - 로그인 모달, 아이콘 및 텍스트 간격 조정

## 🛠 작업 내용

* 로그인 모달의 폰트 크기, 내부 간격, 닫기 아이콘 크기 수정
* 카테고리와 장소명 사이 간격 조정
* 북마크 아이콘을 디자인 시안에 맞게 SVG로 교체
* 홈 화면 드롭다운 박스 위치 조정
* 상세 페이지 내 장소 정보 텍스트 간격 조절

## 📚 추가 내용 (선택)

* 북마크 아이콘은 Figma 시안을 참고하여 커스텀 SVG로 대체함
