### PR TITLE
프로필 인스타 아이디 삭제 버그 수정 및 UI 스타일 개선

### DIFF
--- a/src/app/(root)/profile/editor/page.tsx
+++ b/src/app/(root)/profile/editor/page.tsx
@@ -71,11 +71,10 @@ export default function ProfileEditorPage() {
 
       const nickname = data.nickname.trim();
       const description = data.description;
-      const insta_id = data.insta_id
-        ? data.insta_id.trim().startsWith('@')
-          ? data.insta_id.trim()
-          : `@${data.insta_id.trim()}`
-        : undefined;
+
+      const rawInstaId = data.insta_id.trim();
+      const insta_id =
+        rawInstaId === '' ? null : rawInstaId.startsWith('@') ? rawInstaId : `@${rawInstaId}`;
 
       let image_url: string | undefined = undefined;
 

--- a/src/components/common/Card/PostCard/PostCardTitle.tsx
+++ b/src/components/common/Card/PostCard/PostCardTitle.tsx
@@ -10,7 +10,7 @@ function PostCardTitle({ className, title, modal }: PostCardTitleProps) {
   return (
     <h3
       className={cn(
-        'font-bold text-black text-sm web:text-md truncate',
+        'font-bold text-black text-text-2xl web:text-sm truncate',
         modal && '!text-text-xs',
         className
       )}

--- a/src/components/features/detail-log/LogContent.tsx
+++ b/src/components/features/detail-log/LogContent.tsx
@@ -38,11 +38,11 @@ const LogContent = ({ place, idx }: LogContentProps) => {
         </div>
         <div className="flex flex-col web:w-[324px] gap-[2px]">
           <div className="flex gap-1.5 text-light-400 text-text-sm web:text-text-lg">
-            <MapIcon className="w-4.5 h-4.5 mt-1" />
+            <MapIcon className="w-4.5 h-4.5 mt-[1.5px] web:mt-[2.5px]" />
             <span className="break-words block min-w-0">{place.category}</span>
           </div>
           <div className="flex items-start gap-1.5 text-light-400 text-text-sm web:text-text-lg">
-            <LocationIcon className="w-4.5 h-4.5 mt-1 flex-shrink-0" />
+            <LocationIcon className="w-4.5 h-4.5 mt-[1.5px] web:mt-[2.5px] flex-shrink-0" />
             <span className="break-words block min-w-0">{place.address}</span>
           </div>
         </div>


### PR DESCRIPTION
## 📌 작업 주제

- 프로필 수정 시 인스타그램 아이디 삭제 동작 개선
- 일부 UI 요소 스타일 정리

## 🛠 작업 내용

- 프로필 인스타그램 아이디 입력란에서 값을 삭제한 후 저장 시, DB에 null로 반영되도록 수정
- 로그 콘텐츠 제목 폰트 크기를 한 단계 낮춤
- 상세페이지 장소 카테고리 아이콘의 y축 정렬 문제 수정

## 📚 추가 내용 (선택)

- 프로필 입력값 처리 시, trim 후 빈 문자열은 null로 명시적으로 변환하여 Prisma에서 제대로 반영되도록 처리함
