### PR TITLE
글로벌 버튼 오류 수정 및 번역/캐싱/모바일 UI 개선

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -500,7 +500,7 @@
       "city": "City",
       "area": "Area"
     },
-    "sigungu": {
+    "sigunguPage": {
       "groupTitle": "Si/Gun/Gu",
       "sigungu": "Si/Gun/Gu",
       "city": "City"

--- a/src/app/[locale]/(root)/log/[logId]/@placeCollect/(.)placeCollect/page.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/@placeCollect/(.)placeCollect/page.tsx
@@ -1,5 +1,5 @@
 import { LogIdParams } from '@/app/[locale]/(root)/log/[logId]/page';
-import { fetchLog } from '@/app/actions/log';
+import { getLog } from '@/app/actions/log';
 import XButton from '@/components/common/Button/XButton';
 import PlaceCard from '@/components/common/Card/PlaceCard.tsx/PlaceCard';
 import { ModalContent, ModalHeader } from '@/components/common/Modal';
@@ -9,7 +9,7 @@ interface PlaceCollectProps {
 }
 export default async function PlaceCollect({ params }: PlaceCollectProps) {
   const { logId } = await params;
-  const result = await fetchLog(logId);
+  const result = await getLog(logId);
   if (!result.success) {
     return null;
   }

--- a/src/app/[locale]/(root)/log/[logId]/page.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchLog } from '@/app/actions/log';
+import { getLog } from '@/app/actions/log';
 import { getUser } from '@/app/actions/user';
 import { PenBlackIcon, TableIcon } from '@/components/common/Icons';
 import ExtraActionButton from '@/components/features/detail-log/ExtraActionButton';
@@ -19,7 +19,8 @@ interface LogDetailPageProps {
 
 const LogDetailPage = async ({ params }: LogDetailPageProps) => {
   const { logId } = await params;
-  const result = await fetchLog(logId);
+  const result = await getLog(logId);
+
   if (!result.success) {
     notFound();
   }

--- a/src/app/[locale]/(write)/[logId]/edit/page.tsx
+++ b/src/app/[locale]/(write)/[logId]/edit/page.tsx
@@ -1,6 +1,6 @@
 import { LogIdParams } from '@/app/[locale]/(root)/log/[logId]/page';
-import { fetchLog } from '@/app/actions/log';
-import { HOME } from '@/constants/pathname';
+import { getLog } from '@/app/actions/log';
+import { getLocale } from 'next-intl/server';
 import { redirect } from 'next/navigation';
 import LogEditPage from './_EditPage/page';
 interface LogEditServerPageProps {
@@ -9,8 +9,9 @@ interface LogEditServerPageProps {
 
 const LogEditServerPage = async ({ params }: LogEditServerPageProps) => {
   const { logId } = await params;
-  const result = await fetchLog(logId);
-  if (!result.success) redirect(HOME);
+  const locale = await getLocale();
+  const result = await getLog(logId);
+  if (!result.success) redirect(`/${locale}`);
   const logData = result.data;
 
   return <LogEditPage logData={logData} />;

--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -108,6 +108,13 @@ export async function fetchLog(logId: string): Promise<ApiResponse<DetailLog>> {
   }
 }
 
+export async function getLog(logId: string) {
+  return unstable_cache(() => fetchLog(logId), [...cacheTags.logDetail(logId)], {
+    tags: [cacheTags.logDetail(logId), globalTags.logAll], // 상위 그룹 태그 추가
+    revalidate: 300,
+  })();
+}
+
 // ===================================================================
 // 로그 삭제
 // ===================================================================
@@ -240,7 +247,7 @@ export async function getLogs(params: LogsParams) {
     () => fetchLogs(params),
     [...queryKey].map((v) => v ?? ''),
     {
-      tags: [tagKey, 'log:all'], // 상위 그룹 태그 추가
+      tags: [tagKey, globalTags.logAll], // 상위 그룹 태그 추가
       revalidate: 300,
     }
   )();
@@ -470,7 +477,7 @@ export async function getSearchLogs(params: SearchParams) {
   return unstable_cache(() => fetchSearchLogs(params), [...searchKeys.list(params)], {
     tags: [
       cacheTags.searchList(params), // 조건별로 구분되는 태그
-      'search:all', // 전체 무효화용 상위 태그
+      globalTags.searchAll, // 전체 무효화용 상위 태그
     ],
     revalidate: 300,
   })();

--- a/src/components/common/Header/Header/components/ToggleLocaleButton.tsx
+++ b/src/components/common/Header/Header/components/ToggleLocaleButton.tsx
@@ -11,7 +11,7 @@ export default function ToggleLocaleButton() {
   const nextLocale = locale === 'ko' ? 'en' : 'ko';
 
   return (
-    <Button variant={'ghost'} size={'icon'} className="relative group">
+    <Button variant={'ghost'} size={'icon'} asChild className="relative group">
       <Link href={{ pathname }} locale={nextLocale}>
         <GlobeIcon className="absolute group-hover:opacity-0" />
         <GlobeBlackIcon className="opacity-0 group-hover:opacity-100" />

--- a/src/components/common/Header/Header2.tsx
+++ b/src/components/common/Header/Header2.tsx
@@ -1,15 +1,16 @@
 import { Button } from '@/components/ui/button';
-import { HOME } from '@/constants/pathname';
+import { getLocale } from 'next-intl/server';
 import Link from 'next/link';
 import BackButton from '../Button/BackButton';
 import { HomeIcon } from '../Icons';
 
-const Header2 = () => {
+const Header2 = async () => {
+  const locale = await getLocale();
   return (
     <header className="py-[15px] bg-white space-x-2">
       <BackButton plain />
       <Button variant={'ghost'} size={'icon'} asChild>
-        <Link href={HOME}>
+        <Link href={`/${locale}`}>
           <HomeIcon />
         </Link>
       </Button>

--- a/src/components/common/Header/Logo.tsx
+++ b/src/components/common/Header/Logo.tsx
@@ -1,9 +1,10 @@
-import { HOME } from '@/constants/pathname';
+import { getLocale } from 'next-intl/server';
 import Link from 'next/link';
 
-const Logo = () => {
+const Logo = async () => {
+  const locale = await getLocale();
   return (
-    <Link href={HOME} className="text-white text-[23px] font-prompt">
+    <Link href={`/${locale}`} className="text-white text-[23px] font-prompt">
       Spoteditor
     </Link>
   );

--- a/src/components/features/log/register/tags/SingleTagGroup.tsx
+++ b/src/components/features/log/register/tags/SingleTagGroup.tsx
@@ -60,7 +60,7 @@ const SingleTagGroup = ({ title, type, nextPath }: SingleTagGroupProps) => {
   } else if (tagGroupTitle === '지역') {
     localeTitle = 'Register.CityPage.area';
   } else if (tagGroupTitle === '시/군/구') {
-    localeTitle = 'Register.sigungu.sigungu';
+    localeTitle = 'Register.sigunguPage.sigungu';
   }
   const t = useTranslations();
 

--- a/src/components/features/profile/ProfileTabContent/components/ProfileTabs/ProfileTabs.tsx
+++ b/src/components/features/profile/ProfileTabContent/components/ProfileTabs/ProfileTabs.tsx
@@ -23,8 +23,9 @@ export default function ProfileTabs({ me, userId }: ProfileTabsProps) {
   const onTabClick = (tab: 'myLog' | 'savedSpaces' | 'savedLog') => {
     setTab(tab);
   };
+
   return (
-    <nav className="w-full flex justify-center web:justify-start items-center gap-[21px] web:gap-7.5 mb-5 web:mb-7.5">
+    <nav className="w-full flex justify-center web:justify-start items-center gap-[14px] web:gap-7.5 max-[374px]:gap-[14px] mb-5 web:mb-7.5">
       <TabButton
         tabKey="myLog"
         userId={userId}

--- a/src/hooks/mutations/log/useLogDeleteMutation.ts
+++ b/src/hooks/mutations/log/useLogDeleteMutation.ts
@@ -1,8 +1,7 @@
 import { logKeys, placeKeys, searchKeys } from '@/app/actions/keys';
 import { deleteLog } from '@/app/actions/log';
-import { HOME } from '@/constants/pathname';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
@@ -12,6 +11,7 @@ interface LogDeleteMutationProps {
 
 const useLogDeleteMutation = () => {
   const t = useTranslations('Toast.logDelete');
+  const locale = useLocale();
   const router = useRouter();
   const queryClient = useQueryClient();
   return useMutation({
@@ -24,7 +24,7 @@ const useLogDeleteMutation = () => {
         keysToInvalidate.forEach((key) => {
           queryClient.removeQueries({ queryKey: key, exact: false });
         });
-        router.replace(HOME);
+        router.replace(`/${locale}`);
       }
     },
     onError: () => {


### PR DESCRIPTION
## 📌 작업 주제

* 글로벌 버튼 동작 오류 수정
* 다국어 번역 에러 수정
* 단일 로그 SSR 캐싱 적용
* 프로필 페이지 탭 모바일 UI 개선

## 🛠 작업 내용

* 글로벌 버튼이 간헐적으로 클릭되지 않던 문제 수정
  → `<button><a></a></button>` 구조를 개선하고, `asChild` 옵션을 적용해 `<Link>`가 버튼처럼 동작하도록 처리
* `/` 접근 시 브라우저 언어(locale)에 따라 `/ko`, `/en`으로 자동 라우팅 처리
* 누락된 번역 키 추가 및 한국어/영어 간 번역 불일치 내용 정리
* 단일 로그에 SSR 캐시(5분)를 적용
* 모바일 환경에서 프로필 페이지 탭 간 텍스트가 겹치던 문제 해결
  → 크롬 모바일 디바이스 최소 너비(374px)를 기준으로 `max-[374px]:gap-[14px]` 적용
