### PR TITLE
SSR 캐시 무효화 미적용으로 인한 북마크 반영 오류 수정

### DIFF
--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -115,6 +115,11 @@ export async function getLog(logId: string) {
   })();
 }
 
+/* 북마크 시 서버캐시 무효화 */
+export async function revalidateLog(logId: string) {
+  revalidateTag(cacheTags.logDetail(logId));
+}
+
 // ===================================================================
 // 로그 삭제
 // ===================================================================

--- a/src/app/api/log/bookmark/check/route.ts
+++ b/src/app/api/log/bookmark/check/route.ts
@@ -1,3 +1,4 @@
+import { revalidateLog } from '@/app/actions/log';
 import { getUser } from '@/app/actions/user';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
@@ -103,6 +104,10 @@ export async function POST(req: NextRequest) {
         log_id: String(logId),
       },
     });
+
+    /* 북마크 시 로그 서버캐시 무효화(버그 수정) */
+    await revalidateLog(logId);
+
     return NextResponse.json({ success: true, isBookmark: true }, { status: 200 });
   } catch (_error) {
     console.error(_error);
@@ -162,6 +167,9 @@ export async function DELETE(req: NextRequest) {
         { status: 404 }
       );
     }
+
+    /* 북마크 시 로그 서버캐시 무효화(버그 수정) */
+    await revalidateLog(logId);
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## 📌 작업 주제

* 로그 북마크 후 SSR/CSR 캐시 불일치 문제 수정

## 🛠 작업 내용

* `log/bookmark/check` API(POST, DELETE)에서 `revalidateTag`를 적용해 SSR 캐시 무효화 처리
* 메인 페이지 등에서 북마크 클릭 후 로그 상세 페이지 진입 시 북마크 수치가 이전 상태로 되돌아가는 문제 해결
* 메인 페이지 등에서 북마크 클릭 → 상세 페이지 이동 시에도 정확한 카운트가 반영되도록 처리
