### PR TITLE
next-intl Link 컴포넌트 분리 및 레이아웃 시프트 방지 리팩토링

### DIFF
--- a/src/app/[locale]/(root)/@modal/(.)login/page.tsx
+++ b/src/app/[locale]/(root)/@modal/(.)login/page.tsx
@@ -1,8 +1,7 @@
 import XButton from '@/components/common/Button/XButton';
 import { ModalContent, ModalHeader } from '@/components/common/Modal';
+import LoginAgreementNotice from '@/components/features/login/LoginAgreementNotice';
 import SocialLoginButtons from '@/components/features/login/SocialLoginButtons';
-import { PRIVACY_PATHS, TERMS_PATHS } from '@/constants/pathname';
-import { Link } from '@/i18n/navigation';
 import { getTranslations } from 'next-intl/server';
 
 export default async function LoginModal() {
@@ -27,19 +26,7 @@ export default async function LoginModal() {
         </p>
       </section>
       <SocialLoginButtons />
-      <p className="font-pretendard text-light-300 text-center text-text-2xs web:text-text-xs">
-        {t('agreementNotice.beforeLinks')}{' '}
-        <Link href={PRIVACY_PATHS.PRIVACY} className="border-b border-light-300 pb-[0.5px]">
-          {t('privacyPolicy')}
-        </Link>{' '}
-        {t('agreementNotice.middle')}{' '}
-        <Link href={TERMS_PATHS.TERMS} className="border-b border-light-300 pb-[0.5px]">
-          {t('termsOfService')}
-        </Link>
-        {t('agreementNotice.afterLinks')}
-        <br />
-        {t('dataCollection')}
-      </p>
+      <LoginAgreementNotice />
     </ModalContent>
   );
 }

--- a/src/app/[locale]/(root)/log/[logId]/page.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/page.tsx
@@ -1,13 +1,10 @@
 import { logKeys } from '@/app/actions/keys';
 import { getLog } from '@/app/actions/log';
 import { getUser } from '@/app/actions/user';
-import { PenBlackIcon, TableIcon } from '@/components/common/Icons';
-import ExtraActionButton from '@/components/features/detail-log/ExtraActionButton';
 import LogAuthorIntro from '@/components/features/detail-log/LogAuthorIntro';
-import LogBookmarkWithCount from '@/components/features/detail-log/LogBookmarkWithCount';
 import LogContentSection from '@/components/features/detail-log/LogContentSection';
+import LogDetailActions from '@/components/features/detail-log/LogDetailActions';
 import LogThumbnail from '@/components/features/detail-log/LogThumbnail';
-import { Link } from '@/i18n/navigation';
 import { getQueryClient } from '@/lib/utils';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
@@ -52,22 +49,7 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
           <LogContentSection logId={logId} />
         </main>
 
-        <div className="flex flex-col items-center gap-2 fixed z-10 bottom-10 web:right-[50px] right-4">
-          {isAuthor ? (
-            <ExtraActionButton className="w-11 h-11">
-              <Link href={`/${logData.log_id}/edit`}>
-                <PenBlackIcon />
-              </Link>
-            </ExtraActionButton>
-          ) : (
-            <LogBookmarkWithCount logId={logData.log_id} />
-          )}
-          <ExtraActionButton className="w-11 h-11" asChild>
-            <Link href={`/log/${logData.log_id}/placeCollect`}>
-              <TableIcon />
-            </Link>
-          </ExtraActionButton>
-        </div>
+        <LogDetailActions isAuthor={isAuthor} logId={logId} />
       </div>
     </HydrationBoundary>
   );

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,6 +1,5 @@
-import { PRIVACY_PATHS, TERMS_PATHS } from '@/constants/pathname';
-import { Link } from '@/i18n/navigation';
 import ContactLink from './ContactLink';
+import FooterPolicyLinks from './FooterPolicyLinks';
 
 const Footer = () => {
   return (
@@ -9,10 +8,7 @@ const Footer = () => {
 
       <div className="flex flex-col web:flex-row gap-3 justify-between text-light-600">
         <p>©2025 Spoteditor. All Rights are reserved️</p>
-        <div className="flex gap-6">
-          <Link href={PRIVACY_PATHS.PRIVACY}>Privacy Policy</Link>
-          <Link href={TERMS_PATHS.TERMS}>Terms & Conditions</Link>
-        </div>
+        <FooterPolicyLinks />
       </div>
     </footer>
   );

--- a/src/components/common/Footer/FooterPolicyLinks.tsx
+++ b/src/components/common/Footer/FooterPolicyLinks.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { PRIVACY_PATHS, TERMS_PATHS } from '@/constants/pathname';
+import { Link } from '@/i18n/navigation';
+
+export default function FooterPolicyLinks() {
+  return (
+    <div className="flex gap-6">
+      <Link href={PRIVACY_PATHS.PRIVACY}>Privacy Policy</Link>
+      <Link href={TERMS_PATHS.TERMS}>Terms & Conditions</Link>
+    </div>
+  );
+}

--- a/src/components/common/Header/Header/HomeLinkButton.tsx
+++ b/src/components/common/Header/Header/HomeLinkButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { HomeIcon } from '@/components/common/Icons';
+import { Button } from '@/components/ui/button';
+import { HOME } from '@/constants/pathname';
+import { Link } from '@/i18n/navigation';
+
+export default function HomeLinkButton() {
+  return (
+    <Button variant="ghost" size="icon" asChild>
+      <Link href={HOME}>
+        <HomeIcon />
+      </Link>
+    </Button>
+  );
+}

--- a/src/components/common/Header/Header2.tsx
+++ b/src/components/common/Header/Header2.tsx
@@ -1,18 +1,11 @@
-import { Button } from '@/components/ui/button';
-import { HOME } from '@/constants/pathname';
-import { Link } from '@/i18n/navigation';
 import BackButton from '../Button/BackButton';
-import { HomeIcon } from '../Icons';
+import HomeLinkButton from './Header/HomeLinkButton';
 
 const Header2 = () => {
   return (
     <header className="py-[15px] bg-white space-x-2">
       <BackButton plain />
-      <Button variant={'ghost'} size={'icon'} asChild>
-        <Link href={HOME}>
-          <HomeIcon />
-        </Link>
-      </Button>
+      <HomeLinkButton />
     </header>
   );
 };

--- a/src/components/features/detail-log/LogDetailActions.tsx
+++ b/src/components/features/detail-log/LogDetailActions.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { PenBlackIcon, TableIcon } from '@/components/common/Icons';
+import { Link } from '@/i18n/navigation';
+import ExtraActionButton from './ExtraActionButton';
+import LogBookmarkWithCount from './LogBookmarkWithCount';
+
+interface LogDetailActionsProps {
+  isAuthor: boolean;
+  logId: string;
+}
+
+export default function LogDetailActions({ isAuthor, logId }: LogDetailActionsProps) {
+  return (
+    <div className="flex flex-col items-center gap-2 fixed z-10 bottom-10 web:right-[50px] right-4">
+      {isAuthor ? (
+        <ExtraActionButton className="w-11 h-11">
+          <Link href={`/${logId}/edit`}>
+            <PenBlackIcon />
+          </Link>
+        </ExtraActionButton>
+      ) : (
+        <LogBookmarkWithCount logId={logId} />
+      )}
+      <ExtraActionButton className="w-11 h-11" asChild>
+        <Link href={`/log/${logId}/placeCollect`}>
+          <TableIcon />
+        </Link>
+      </ExtraActionButton>
+    </div>
+  );
+}

--- a/src/components/features/detail-log/LogProfile.tsx
+++ b/src/components/features/detail-log/LogProfile.tsx
@@ -1,8 +1,6 @@
 import { getUser } from '@/app/actions/user';
 import FollowingButton from '@/components/common/Button/FollowingButton';
-import UserImage from '@/components/common/UserImage';
-import { PROFILE_PATHS } from '@/constants/pathname';
-import { Link } from '@/i18n/navigation';
+import LogProfileLink from './LogProfileLink';
 
 interface LogProfileProps {
   userId: string;
@@ -15,10 +13,7 @@ const LogProfile = async ({ userId, userImage, userNickname }: LogProfileProps) 
   return (
     <div className="flex items-start py-1.5">
       <div className="flex items-center gap-4">
-        <Link href={`${PROFILE_PATHS.PROFILE}/${userId}`} className="flex items-center gap-2">
-          <UserImage imgSrc={userImage} className="w-6 h-6" />
-          <span className="text-text-sm web:text-text-md font-semibold">{userNickname}</span>
-        </Link>
+        <LogProfileLink userId={userId} userImage={userImage} userNickname={userNickname} />
         {me && me?.user_id !== userId && <FollowingButton userId={userId} />}
       </div>
     </div>

--- a/src/components/features/detail-log/LogProfileLink.tsx
+++ b/src/components/features/detail-log/LogProfileLink.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import UserImage from '@/components/common/UserImage';
+import { PROFILE_PATHS } from '@/constants/pathname';
+import { Link } from '@/i18n/navigation';
+
+interface LogProfileLinkProps {
+  userId: string;
+  userImage: string;
+  userNickname: string;
+}
+
+export default function LogProfileLink({ userId, userImage, userNickname }: LogProfileLinkProps) {
+  return (
+    <Link href={`${PROFILE_PATHS.PROFILE}/${userId}`} className="flex items-center gap-2">
+      <UserImage imgSrc={userImage} className="w-6 h-6" />
+      <span className="text-text-sm web:text-text-md font-semibold">{userNickname}</span>
+    </Link>
+  );
+}

--- a/src/components/features/login/LoginAgreementNotice.tsx
+++ b/src/components/features/login/LoginAgreementNotice.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { PRIVACY_PATHS, TERMS_PATHS } from '@/constants/pathname';
+import { Link } from '@/i18n/navigation';
+import { useTranslations } from 'next-intl';
+
+export default function LoginAgreementNotice() {
+  const t = useTranslations('LoginModal');
+
+  return (
+    <p className="font-pretendard text-light-300 text-center text-text-2xs web:text-text-xs">
+      {t('agreementNotice.beforeLinks')}{' '}
+      <Link href={PRIVACY_PATHS.PRIVACY} className="border-b border-light-300 pb-[0.5px]">
+        {t('privacyPolicy')}
+      </Link>
+      {t('agreementNotice.middle')}{' '}
+      <Link href={TERMS_PATHS.TERMS} className="border-b border-light-300 pb-[0.5px]">
+        {t('termsOfService')}
+      </Link>
+      {t('agreementNotice.afterLinks')}
+      <br />
+      {t('dataCollection')}
+    </p>
+  );
+}


### PR DESCRIPTION
## 📌 작업 주제

- next-intl의 Link 컴포넌트 클라이언트 전용 제한 대응
- 레이아웃 시프트 없는 안전한 분리 리팩토링

## 🛠 작업 내용

- 서버 컴포넌트 내 사용 중이던 Link 컴포넌트를 별도 클라이언트 컴포넌트로 분리
  - Footer → `FooterPolicyLinks`로 분리
  - Header2 → `HomeLinkButton`으로 분리
  - LogProfile → `LogProfileLink`로 분리
  - LoginModal → `LoginAgreementNotice`로 분리
- 레이아웃 시프트가 발생하지 않도록 고정 영역 분리, min-height 확보 등 구조 안정성 유지
- SSR 로직(getUser 등)은 유지하면서 클라이언트 전용 기능만 안전하게 이동

## 📚 추가 내용 (선택)

- 레이아웃 시프트가 발생하지 않도록 다음 기준을 참고해 분리함
  - 화면 고정(fixed)처럼 레이아웃에 영향을 주지 않는 경우 → 바로 분리
  - 본문 안쪽 흐름처럼 위치 변화가 민감한 경우 → 공간을 미리 확보하거나, 서버에서 필요한 데이터를 먼저 넘겨받도록 처리