### PR TITLE
feat: Microsoft Clarity 스크립트 추가

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -46,6 +46,19 @@ export default async function RootLayout({
           href="/favicons/android-icon-192x192.png"
         />
         <meta name="msapplication-TileImage" content="/favicons/ms-icon-144x144.png" />
+        {/* Microsoft Clarity 삽입 */}
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: `
+        (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", ${process.env.NEXT_PUBLIC_CLARITY_ID});
+      `,
+          }}
+        />
       </head>
       <body
         className={`${pretendard.variable} ${untitled.variable} ${prompt.variable} antialiased`}

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -2,5 +2,6 @@ declare namespace NodeJS {
   interface ProcessEnv {
     NEXT_PUBLIC_SITE_URL_LOCAL: string;
     NEXT_PUBLIC_GA_ID: string;
+    NEXT_PUBLIC_CLARITY_ID: string;
   }
 }


### PR DESCRIPTION
## 📌 작업 주제

* Microsoft Clarity 사용자 행동 분석 스크립트 연동

## 🛠 작업 내용

* `layout.tsx`의 `<head>`에 Clarity 스크립트 삽입
* Clarity Project ID는 환경변수 `NEXT_PUBLIC_CLARITY_ID`로 관리
* 사용자 행동 추적을 위한 스크립트가 클라이언트에서 정상적으로 로드되도록 `dangerouslySetInnerHTML` 방식 사용

## 📚 추가 내용 (선택)

* Clarity 데이터 수집은 몇 분 후부터 대시보드에 반영됨
* 향후 `Google Analytics`, `Clarity`, `Hotjar` 등을 통합 관리하고 싶다면 별도 `AnalyticsProvider` 컴포넌트로 추출 가능