### PR TITLE
홈 화면 장소 리스트 기능 구현 및 타입·상수 구조 정리

### DIFF
--- a/src/app/[locale]/(root)/page.tsx
+++ b/src/app/[locale]/(root)/page.tsx
@@ -1,13 +1,15 @@
 import CarouselSection from '@/components/features/home/CarouselSection/CarouselSection';
 import InfoBanners from '@/components/features/home/InfoBanner/InfoBanners';
 import LatestLogContentSection from '@/components/features/home/LatestLogContentSection/LatestLogContentSection';
+import LatestPlaceContentSection from '@/components/features/home/LatestPlaceContentSection/LatestPlaceContentSection';
 
 interface MainPageProps {
-  searchParams: Promise<{ logPage: string; popularityPage: string }>;
+  searchParams: Promise<{ logPage: string; popularityPage: string; placePage: string }>;
 }
 
 const MainPage = async ({ searchParams }: MainPageProps) => {
-  const { popularityPage, logPage } = await searchParams;
+  const { popularityPage, logPage, placePage } = await searchParams;
+
   /* 참고: logPage는 URL 쿼리스트링에서 파싱되기 때문에 타입은 string이지만 값이 항상 보장되진 않음
   예: logPage=NaN, logPage=abc, logPage= 등 → Number() 처리 후 NaN으로 바뀜 */
   const parsedPopularityPage = Number(popularityPage);
@@ -17,12 +19,16 @@ const MainPage = async ({ searchParams }: MainPageProps) => {
   const parsedLogPage = Number(logPage);
   const currentLogPage = isNaN(parsedLogPage) || parsedLogPage < 1 ? 1 : parsedLogPage;
 
+  const parsedPlacePage = Number(placePage);
+  const currentPlacePage = isNaN(parsedPlacePage) || parsedPlacePage < 1 ? 1 : parsedPlacePage;
+
   return (
     <main className="h-full">
       {/* <Login /> */}
       {/* <Hero /> */}
       <InfoBanners />
       <div className="pt-[60px] pb-[140px] px-4 web:px-[50px] space-y-20">
+        <LatestPlaceContentSection currentPage={currentPlacePage} />
         <CarouselSection currentPage={currentPopularityPage} />
         <LatestLogContentSection currentPage={currentLogPage} />
       </div>

--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -2,6 +2,7 @@
 
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { CACHE_REVALIDATE_TIME, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '@/constants/fetchConfig';
 import { createClient } from '@/lib/supabase/server';
 import { ApiResponse } from '@/types/api/common';
 import { DetailLog, logBookmarkListParams, LogsParams, LogsResponse } from '@/types/api/log';
@@ -13,10 +14,6 @@ import { logKeys, searchKeys } from './keys';
 import { deleteNestedFolderFiles } from './storage';
 import { cacheTags, globalTags } from './tags';
 import { getUser } from './user';
-
-const DEFAULT_PAGE_SIZE = 12;
-const MAX_PAGE_SIZE = 30;
-const CACHE_REVALIDATE_TIME = 300; // 5분
 
 // ===================================================================
 // 단일 로그

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -15,7 +15,7 @@ export async function fetchBookmarkedPlaces({
   userId,
   currentPage = 1,
   pageSize = 12,
-}: PlaceBookmarkListParmas): Promise<PlacesReseponse> {
+}: PlaceBookmarkListParmas): Promise<PlacesBookmarkReseponse> {
   try {
     const safePage = Math.max(1, currentPage);
     const safeSize = Math.min(Math.max(1, pageSize), 30);

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -59,6 +59,7 @@ export async function fetchPlaces({
               },
               address: {
                 select: {
+                  country: true,
                   city: true,
                   sigungu: true,
                 },
@@ -81,6 +82,7 @@ export async function fetchPlaces({
         nickname: place.log?.users.nickname?.toString() ?? '',
       },
       address: {
+        country: place.log?.address[0].country?.toString() ?? '',
         city: place.log?.address[0].city?.toString() ?? '',
         sigungu: place.log?.address[0].sigungu?.toString() ?? '',
       },

--- a/src/app/api/places/route.ts
+++ b/src/app/api/places/route.ts
@@ -1,0 +1,34 @@
+import { getPlaces } from '@/app/actions/place';
+import { ERROR_CODES } from '@/constants/errorCode';
+import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const currentPage = parseInt(searchParams.get('currentPage') || '1');
+  const pageSize = parseInt(searchParams.get('pageSize') || '12');
+
+  try {
+    const result = await getPlaces({ currentPage, pageSize });
+
+    if (!result.success) {
+      return NextResponse.json(result, {
+        status: 404,
+      });
+    }
+
+    return NextResponse.json(result, {
+      status: result.meta?.httpStatus ?? 200,
+    });
+  } catch (_error) {
+    console.error(_error);
+    return NextResponse.json(
+      {
+        success: false,
+        msg: ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR,
+        errorCode: ERROR_CODES.COMMON.INTERNAL_SERVER_ERROR,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/features/home/LatestPlaceContentSection/LatestPlaceContent.tsx
+++ b/src/components/features/home/LatestPlaceContentSection/LatestPlaceContent.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import PlaceBookMarkButton from '@/components/common/Button/Bookmark/PlaceBookMarkButton';
+import MotionCard from '@/components/common/Card/MotionCard';
+import {
+  PostCardImage,
+  PostCardLocation,
+  PostCardTitle,
+  PostCardWrapper,
+} from '@/components/common/Card/PostCard';
+import CustomPagination from '@/components/common/CustomPagination';
+import FallbackMessage from '@/components/common/FallbackMessage';
+import { TitledSection } from '@/components/common/SectionBlock';
+import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import usePlaces from '@/hooks/queries/place/usePlaces';
+import useQueryPagination from '@/hooks/useQueryPagination';
+import { Link } from '@/i18n/navigation';
+import { useRef } from 'react';
+
+interface LatestPlaceContentProps {
+  currentPage: number;
+}
+
+export default function LatestPlaceContent({ currentPage }: LatestPlaceContentProps) {
+  const contentRef = useRef<HTMLElement | null>(null);
+  const { handlePageChange } = useQueryPagination('placePage', currentPage, contentRef);
+  const { data } = usePlaces({ currentPage, pageSize: 12, sort: 'latest' });
+  if ((data && !data?.success) || data?.data.length === 0) {
+    return (
+      <FallbackMessage
+        message={
+          !data.success
+            ? ERROR_MESSAGES.COMMON.INTERNAL_SERVER_ERROR
+            : ERROR_MESSAGES.PLACE.LIST_EMPTY
+        }
+        className="items-center"
+      />
+    );
+  }
+  return (
+    <section ref={contentRef}>
+      <TitledSection title="Latest" subTitle="Places">
+        <PostCardWrapper className="mb-[50px]">
+          {data?.data.map((place) => (
+            <MotionCard key={place.place_id} className="relative group">
+              <Link href={`/log/${place?.log_id}`}>
+                <PostCardImage
+                  author={String(place?.user.nickname)}
+                  imageUrl={String(place.place_images)}
+                />
+                <PostCardTitle title={String(place.name)} />
+                <PostCardLocation
+                  city={String(place.address.city)}
+                  country={String(place.address.country)}
+                  sigungu={String(place.address.sigungu)}
+                />
+              </Link>
+              <PlaceBookMarkButton placeId={place.place_id} />
+            </MotionCard>
+          ))}
+        </PostCardWrapper>
+        {data?.success && data.meta?.pagination && (
+          <CustomPagination
+            currentPage={currentPage}
+            totalPages={Number(data.meta.pagination.totalPages)}
+            onChangePage={handlePageChange}
+          />
+        )}
+      </TitledSection>
+    </section>
+  );
+}

--- a/src/components/features/home/LatestPlaceContentSection/LatestPlaceContentSection.tsx
+++ b/src/components/features/home/LatestPlaceContentSection/LatestPlaceContentSection.tsx
@@ -1,0 +1,25 @@
+import { placeKeys } from '@/app/actions/keys';
+import { getPlaces } from '@/app/actions/place';
+import { getQueryClient } from '@/lib/utils';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import LatestPlaceContent from './LatestPlaceContent';
+
+interface LatestPlaceContentSectionProps {
+  currentPage: number;
+}
+
+export default async function LatestPlaceContentSection({
+  currentPage,
+}: LatestPlaceContentSectionProps) {
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: placeKeys.list({ currentPage, pageSize: 12, sort: 'latest' }),
+    queryFn: () => getPlaces({ currentPage, pageSize: 12, sort: 'latest' }),
+  });
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <LatestPlaceContent currentPage={currentPage} />
+    </HydrationBoundary>
+  );
+}

--- a/src/constants/fetchConfig.ts
+++ b/src/constants/fetchConfig.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_PAGE_SIZE = 12;
+export const MAX_PAGE_SIZE = 30;
+export const CACHE_REVALIDATE_TIME = 300; // 5분

--- a/src/hooks/queries/place/usePlaces.ts
+++ b/src/hooks/queries/place/usePlaces.ts
@@ -1,0 +1,28 @@
+import { placeKeys } from '@/app/actions/keys';
+import { toQueryString } from '@/lib/utils';
+import { PlacesParams, PlacesReseponse } from '@/types/api/place';
+import { keepPreviousData, useQuery, UseQueryOptions } from '@tanstack/react-query';
+
+async function fetchUsePlaces(params: PlacesParams): Promise<PlacesReseponse> {
+  const query = toQueryString(params);
+  const res = await fetch(`/api/places?${query}`);
+  const data = await res.json();
+  return data;
+}
+
+export default function usePlaces(
+  { currentPage = 1, pageSize = 12, sort }: Partial<PlacesParams> = {},
+  options?: Partial<UseQueryOptions<PlacesReseponse, Error>>
+) {
+  const params = {
+    currentPage,
+    pageSize,
+    sort,
+  };
+  return useQuery({
+    queryKey: placeKeys.list(params),
+    queryFn: () => fetchUsePlaces(params),
+    placeholderData: keepPreviousData,
+    ...options,
+  });
+}

--- a/src/hooks/queries/place/usePlacesBookmark.ts
+++ b/src/hooks/queries/place/usePlacesBookmark.ts
@@ -2,10 +2,10 @@ import { placeKeys } from '@/app/actions/keys';
 import { toQueryString } from '@/lib/utils';
 import { useProfileTabStore } from '@/stores/profileStore';
 import { BookmarkParams } from '@/types/api/common';
-import { PlacesReseponse } from '@/types/api/place';
+import { PlacesBookmarkReseponse } from '@/types/api/place';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-async function fetchUsePlacesBookmark(params: BookmarkParams): Promise<PlacesReseponse> {
+async function fetchUsePlacesBookmark(params: BookmarkParams): Promise<PlacesBookmarkReseponse> {
   const query = toQueryString(params);
   const res = await fetch(`/api/places/bookmark?${query}`);
   const data = await res.json();

--- a/src/types/api/place.d.ts
+++ b/src/types/api/place.d.ts
@@ -1,20 +1,41 @@
 import { Tables } from '../supabase';
 import { ApiResponse, PaginationParams } from './common';
 
-type IPlace = Pick<
+type IBookmarkPlace = Pick<
   Tables<'place'>,
   'place_id' | 'log_id' | 'name' | 'description' | 'address' | 'category'
 >;
 type PlaceImage = Tables<'place_images'>;
 type User = Pick<Tables<'users'>, 'nickname' | 'user_id'>;
 
-interface Place extends IPlace {
+interface BookmarkPlace extends IBookmarkPlace {
   user: User;
   image: PlaceImage;
 }
 
+type Place = {
+  place_id: string;
+  log_id: string;
+  name: string;
+  place_images: string;
+  user: {
+    user_id: string;
+    nickname: string;
+  };
+  address: {
+    city: string;
+    sigungu: string;
+  };
+};
+
 export type PlacesReseponse = ApiResponse<Place[]>;
 
+export type PlacesBookmarkReseponse = ApiResponse<BookmarkPlace[]>;
+
+/* 장소 리스트 */
+type PlacesParams = PaginationParams;
+
+/* 장소북마크 리스트 */
 export interface PlaceBookmarkListParmas extends PaginationParams {
   userId: string;
 }

--- a/src/types/api/place.d.ts
+++ b/src/types/api/place.d.ts
@@ -23,6 +23,7 @@ type Place = {
     nickname: string;
   };
   address: {
+    country: string
     city: string;
     sigungu: string;
   };


### PR DESCRIPTION
## 📌 작업 주제

홈 화면 장소 리스트 기능 구현 및 관련 타입/상수 정리


## 🛠 작업 내용

* 장소 리스트 API 라우트 핸들러(`GET /places`) 구현
* 장소 리스트 쿼리 훅(`usePlaces`) 구현
* SSR 캐시 함수 (`getPlaces`) 구현
* 홈 화면에 최신 장소 리스트(Latest Places) 섹션 UI 추가
* `DEFAULT_PAGE_SIZE`, `CACHE_REVALIDATE_TIME` 등 상수 분리 → `constants/` 폴더로 이동

## 📚 추가 내용 (선택)

* 정렬 방식은 최신순/인기순을 처리할 수 있도록 구성
