### PR TITLE
최신 장소 반영 오류 수정 및 캐시 전략 개선

### DIFF
--- a/prisma/prisma.ts
+++ b/prisma/prisma.ts
@@ -1,11 +1,13 @@
 import { PrismaClient } from '@prisma/client';
 
-declare global {
-  var prisma: PrismaClient | undefined;
-}
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
 
-export const prisma = global.prisma ?? new PrismaClient({ log: ['error'] });
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
 
 if (process.env.NODE_ENV !== 'production') {
-  global.prisma = prisma;
+  globalForPrisma.prisma = prisma;
 }
+
+export default prisma;

--- a/src/app/[locale]/(root)/auth/callback/auth.ts
+++ b/src/app/[locale]/(root)/auth/callback/auth.ts
@@ -1,5 +1,5 @@
 import { SupabaseClient } from '@supabase/supabase-js';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 
 export async function upsertGoogleUser(supabase: SupabaseClient<any, 'public', any>) {
   /* 로그인된 유저 정보 가져오기 (auth.users 기준) */

--- a/src/app/[locale]/(root)/log/[logId]/not-found.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/not-found.tsx
@@ -1,7 +1,14 @@
+import { logKeys, placeKeys } from '@/app/actions/keys';
+import { globalTags } from '@/app/actions/tags';
 import ErrorTemplate from '@/components/common/ErrorTemplate';
 import { getTranslations } from 'next-intl/server';
+import { revalidateTag } from 'next/cache';
 
 export default async function NotFound() {
+  revalidateTag(globalTags.logAll);
+  revalidateTag(globalTags.placeAll);
   const t = await getTranslations('NotFoundPage');
-  return <ErrorTemplate message={t('logMessage')} />;
+  return (
+    <ErrorTemplate message={t('logMessage')} invalidateKeys={[logKeys.all[0], placeKeys.all[0]]} />
+  );
 }

--- a/src/app/[locale]/(root)/profile/[userId]/not-found.tsx
+++ b/src/app/[locale]/(root)/profile/[userId]/not-found.tsx
@@ -1,7 +1,11 @@
+import { userKeys } from '@/app/actions/keys';
+import { globalTags } from '@/app/actions/tags';
 import ErrorTemplate from '@/components/common/ErrorTemplate';
 import { getTranslations } from 'next-intl/server';
+import { revalidatePath } from 'next/cache';
 
 export default async function NotFound() {
+  revalidatePath(globalTags.userAll);
   const t = await getTranslations('NotFoundPage');
-  return <ErrorTemplate message={t('userMessage')} />;
+  return <ErrorTemplate message={t('userMessage')} invalidateKeys={[userKeys.all[0]]} />;
 }

--- a/src/app/actions/log-register.ts
+++ b/src/app/actions/log-register.ts
@@ -177,7 +177,7 @@ async function insertPlaceImageData(supabase: SupabaseClient, placeImageDataList
 
 // 캐시 무효화 함수
 function invalidateCache() {
-  const tagsToInvalidate = [globalTags.logAll, globalTags.logListAll, globalTags.searchAll];
+  const tagsToInvalidate = [globalTags.logAll, globalTags.placeAll, globalTags.searchAll];
 
   tagsToInvalidate.forEach((tag) => revalidateTag(tag));
 }

--- a/src/app/actions/log-update.ts
+++ b/src/app/actions/log-update.ts
@@ -216,15 +216,7 @@ async function deletePlaceImagesFromStorage(supabase: SupabaseClient, imageIds: 
 }
 
 function invalidateCache() {
-  const tagsToInvalidate = [
-    globalTags.logAll,
-    globalTags.logBookmarkAll,
-    globalTags.logListAll,
-    globalTags.placeAll,
-    globalTags.placeBookmarkAll,
-    globalTags.placeListAll,
-    globalTags.searchAll,
-  ];
+  const tagsToInvalidate = [globalTags.logAll, globalTags.placeAll, globalTags.searchAll];
 
   tagsToInvalidate.forEach((tag) => revalidateTag(tag));
 }

--- a/src/app/actions/log.ts
+++ b/src/app/actions/log.ts
@@ -9,7 +9,7 @@ import { DetailLog, logBookmarkListParams, LogsParams, LogsResponse } from '@/ty
 import { SearchParams, SearchResponse } from '@/types/api/search';
 import { Prisma } from '@prisma/client';
 import { revalidateTag, unstable_cache } from 'next/cache';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 import { logKeys, searchKeys } from './keys';
 import { deleteNestedFolderFiles } from './storage';
 import { cacheTags, globalTags } from './tags';
@@ -133,13 +133,7 @@ export async function deleteLog(logId: string): Promise<ApiResponse<null>> {
     }
 
     /* 캐시 무효화 */
-    const logTagsToInvalidate = [
-      globalTags.logAll,
-      globalTags.logListAll,
-      globalTags.logBookmarkAll,
-      globalTags.placeListAll,
-      globalTags.searchAll,
-    ];
+    const logTagsToInvalidate = [globalTags.logAll, globalTags.placeAll, globalTags.searchAll];
     logTagsToInvalidate.forEach((tag) => revalidateTag(tag));
 
     return { success: true, data: null };
@@ -157,7 +151,7 @@ export async function deleteLog(logId: string): Promise<ApiResponse<null>> {
 // 로그 리스트
 // ===================================================================
 
-async function fetchLogs({
+export async function fetchLogs({
   currentPage = 1,
   pageSize = DEFAULT_PAGE_SIZE,
   sort = 'latest',
@@ -345,7 +339,7 @@ export async function getBookmarkedLogs(params: logBookmarkListParams) {
     {
       tags: [
         cacheTags.logBookmarkList(params), // 특정 페이지 북마크 리스트
-        globalTags.logBookmarkAll, // 전체 북마크 리스트 무효화용 상위 태그
+        globalTags.logAll, // 전체 북마크 리스트 무효화용 상위 태그
       ],
       revalidate: CACHE_REVALIDATE_TIME,
     }
@@ -354,14 +348,14 @@ export async function getBookmarkedLogs(params: logBookmarkListParams) {
 
 /* 북마크 시 서버캐시 무효화 */
 export async function revalidateBookmarkLogs() {
-  revalidateTag(globalTags.logBookmarkAll); // 특정 유저·페이지 무관하게 전체 무효화
+  revalidateTag(globalTags.logAll); // 특정 유저·페이지 무관하게 전체 무효화
 }
 
 // ===================================================================
 // 검색 결과 로그 리스트
 // ===================================================================
 
-async function fetchSearchLogs({
+export async function fetchSearchLogs({
   keyword,
   city,
   sigungu,

--- a/src/app/actions/place.ts
+++ b/src/app/actions/place.ts
@@ -10,7 +10,7 @@ import {
   PlacesReseponse,
 } from '@/types/api/place';
 import { revalidateTag, unstable_cache } from 'next/cache';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 import { placeKeys } from './keys';
 import { cacheTags, globalTags } from './tags';
 
@@ -231,7 +231,7 @@ export async function getBookmarkedPlaces(params: PlaceBookmarkListParmas) {
   return unstable_cache(() => fetchBookmarkedPlaces(params), [...placeKeys.bookmarkList(params)], {
     tags: [
       cacheTags.placeBookmarkList(params), // 개별 사용자별 태그
-      globalTags.placeBookmarkAll, // 전체 북마크 무효화용 태그
+      globalTags.placeAll, // 전체 북마크 무효화용 태그
     ],
     revalidate: 300,
   })();
@@ -239,5 +239,5 @@ export async function getBookmarkedPlaces(params: PlaceBookmarkListParmas) {
 
 /* 북마크 시 서버캐시 무효화 */
 export async function revalidateBookmarkPlaces() {
-  revalidateTag(globalTags.placeBookmarkAll);
+  revalidateTag(globalTags.placeAll);
 }

--- a/src/app/actions/tags.ts
+++ b/src/app/actions/tags.ts
@@ -10,18 +10,12 @@ export const globalTags = {
 
   /* 팔로우 관련 */
   followAll: 'follow:all',
-  followerAll: 'follow:follower:all',
-  followingAll: 'follow:following:all',
 
   /* 로그 관련 */
   logAll: 'log:all',
-  logListAll: 'log:list:all',
-  logBookmarkAll: 'log:bookmark:all',
 
   /* 장소 관련 */
   placeAll: 'place:all',
-  placeListAll: 'place:list:all',
-  placeBookmarkAll: 'place:bookmark:all',
 
   /* 검색 관련 */
   searchAll: 'search:list:all',

--- a/src/app/actions/user.ts
+++ b/src/app/actions/user.ts
@@ -5,7 +5,7 @@ import { createClient } from '@/lib/supabase/server';
 import { PublicUser } from '@/types/api/user';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { revalidateTag, unstable_cache } from 'next/cache';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 import { userKeys } from './keys';
 import { deleteAllFilesRecursively, deleteProfileStorageFolder } from './storage';
 import { cacheTags, globalTags } from './tags';
@@ -89,7 +89,7 @@ export async function getUser() {
 // ===================================================================
 // 퍼블릭 유저 정보 가져오기
 // ===================================================================
-async function fetchPublicUser(userId: string): Promise<PublicUser | null> {
+export async function fetchPublicUser(userId: string): Promise<PublicUser | null> {
   try {
     const user = await prisma.public_users.findUnique({
       where: { user_id: userId },
@@ -164,8 +164,7 @@ export async function patchUser({
     const tagsToInvalidate = [
       globalTags.userAll,
       globalTags.logAll,
-      globalTags.logListAll,
-      globalTags.logBookmarkAll,
+      globalTags.placeAll,
       globalTags.searchAll,
     ];
     tagsToInvalidate.forEach(revalidateTag);
@@ -207,18 +206,8 @@ export async function deleteUser() {
       },
     });
     /* 캐시 무효화 */
-    const tagsToInvalidate = [
-      globalTags.userAll,
-      globalTags.followAll,
-      globalTags.logAll,
-      globalTags.logListAll,
-      globalTags.logBookmarkAll,
-      globalTags.placeAll,
-      globalTags.placeListAll,
-      globalTags.placeBookmarkAll,
-      globalTags.searchAll,
-    ];
-    tagsToInvalidate.forEach(revalidateTag);
+    Object.values(globalTags).forEach(revalidateTag);
+
     return { success: true, msg: ERROR_MESSAGES.USER.DELETE_SUCCESS };
   } catch (error) {
     console.error('유저 삭제 오류', error);

--- a/src/app/api/follow/route.ts
+++ b/src/app/api/follow/route.ts
@@ -2,7 +2,7 @@ import { getUser } from '@/app/actions/user';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 
 /*
   팔로우 관계 설명:

--- a/src/app/api/followers/route.ts
+++ b/src/app/api/followers/route.ts
@@ -1,7 +1,7 @@
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/followings/route.ts
+++ b/src/app/api/followings/route.ts
@@ -1,7 +1,7 @@
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/log/bookmark/check/route.ts
+++ b/src/app/api/log/bookmark/check/route.ts
@@ -3,7 +3,7 @@ import { getUser } from '@/app/actions/user';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);

--- a/src/app/api/logs/bookmark/route.ts
+++ b/src/app/api/logs/bookmark/route.ts
@@ -1,6 +1,8 @@
-import { getBookmarkedLogs } from '@/app/actions/log';
+import { fetchBookmarkedLogs } from '@/app/actions/log';
+import { globalTags } from '@/app/actions/tags';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -22,13 +24,15 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const result = await getBookmarkedLogs({ userId, currentPage, pageSize });
+    const result = await fetchBookmarkedLogs({ userId, currentPage, pageSize });
 
     if (!result.success) {
       return NextResponse.json(result, {
         status: 404,
       });
     }
+
+    revalidateTag(globalTags.logAll);
 
     return NextResponse.json(result, { status: result.meta?.httpStatus ?? 200 });
   } catch (_error) {

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,6 +1,8 @@
-import { getLogs } from '@/app/actions/log';
+import { fetchLogs } from '@/app/actions/log';
+import { globalTags } from '@/app/actions/tags';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -11,7 +13,9 @@ export async function GET(req: NextRequest) {
   const pageSize = parseInt(searchParams.get('pageSize') || '12');
 
   try {
-    const result = await getLogs({ userId, currentPage, pageSize });
+    const result = await fetchLogs({ userId, currentPage, pageSize });
+
+    revalidateTag(globalTags.logAll)
 
     if (!result.success) {
       return NextResponse.json(result, {

--- a/src/app/api/logs/search/route.ts
+++ b/src/app/api/logs/search/route.ts
@@ -1,6 +1,8 @@
-import { getSearchLogs } from '@/app/actions/log';
+import { fetchSearchLogs } from '@/app/actions/log';
+import { globalTags } from '@/app/actions/tags';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -13,13 +15,15 @@ export async function GET(req: NextRequest) {
   const pageSize = parseInt(searchParams.get('pageSize') || '12', 12);
 
   try {
-    const result = await getSearchLogs({
+    const result = await fetchSearchLogs({
       keyword,
       city,
       sigungu,
       currentPage,
       pageSize,
     });
+
+    revalidateTag(globalTags.searchAll);
 
     return NextResponse.json(result, { status: 200 });
   } catch (_error) {

--- a/src/app/api/place/bookmark/check/route.ts
+++ b/src/app/api/place/bookmark/check/route.ts
@@ -3,7 +3,7 @@ import { getUser } from '@/app/actions/user';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from 'prisma/prisma';
+import prisma from 'prisma/prisma';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);

--- a/src/app/api/places/bookmark/route.ts
+++ b/src/app/api/places/bookmark/route.ts
@@ -1,6 +1,8 @@
 import { fetchBookmarkedPlaces } from '@/app/actions/place';
+import { globalTags } from '@/app/actions/tags';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -23,6 +25,8 @@ export async function GET(req: NextRequest) {
 
   try {
     const result = await fetchBookmarkedPlaces({ userId, currentPage, pageSize });
+
+    revalidateTag(globalTags.placeAll);
 
     if (!result.success) {
       return NextResponse.json(result, {

--- a/src/app/api/places/route.ts
+++ b/src/app/api/places/route.ts
@@ -1,6 +1,8 @@
-import { getPlaces } from '@/app/actions/place';
+import { fetchPlaces } from '@/app/actions/place';
+import { globalTags } from '@/app/actions/tags';
 import { ERROR_CODES } from '@/constants/errorCode';
 import { ERROR_MESSAGES } from '@/constants/errorMessages';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -9,7 +11,9 @@ export async function GET(req: NextRequest) {
   const pageSize = parseInt(searchParams.get('pageSize') || '12');
 
   try {
-    const result = await getPlaces({ currentPage, pageSize });
+    const result = await fetchPlaces({ currentPage, pageSize });
+
+    revalidateTag(globalTags.placeAll);
 
     if (!result.success) {
       return NextResponse.json(result, {

--- a/src/app/api/public-user/route.ts
+++ b/src/app/api/public-user/route.ts
@@ -1,4 +1,4 @@
-import { getPublicUser } from '@/app/actions/user';
+import { fetchPublicUser } from '@/app/actions/user';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const user = await getPublicUser(userId);
+    const user = await fetchPublicUser(userId);
     return NextResponse.json({ user });
   } catch (_error) {
     console.error(_error);

--- a/src/components/common/ErrorTemplate.tsx
+++ b/src/components/common/ErrorTemplate.tsx
@@ -2,19 +2,33 @@
 
 import { Button } from '@/components/ui/button';
 import { useRouter } from '@/i18n/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
+import { useEffect } from 'react';
 interface ErrorTemplateProps {
   title?: string;
   message?: string;
+  invalidateKeys?: string[];
 }
 
 export default function ErrorTemplate({
   title = '찾으시는 페이지를 찾을 수 없습니다.',
   message = 'URL 주소를 확인해주세요.',
+  invalidateKeys,
 }: ErrorTemplateProps) {
   const router = useRouter();
   const t = useTranslations('NotFoundPage');
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (invalidateKeys && queryClient) {
+      invalidateKeys.forEach((key) => {
+        queryClient.removeQueries({ queryKey: [key] });
+      });
+    }
+  }, [invalidateKeys, queryClient]);
+
   const handleClick = () => router.replace('/');
   return (
     <main className="flex flex-col items-center justify-center h-dvh grow">

--- a/src/hooks/mutations/log/useLogCreateMutation.ts
+++ b/src/hooks/mutations/log/useLogCreateMutation.ts
@@ -1,4 +1,4 @@
-import { logKeys, searchKeys } from '@/app/actions/keys';
+import { logKeys, placeKeys, searchKeys } from '@/app/actions/keys';
 import { createLog } from '@/app/actions/log-register';
 import { HOME } from '@/constants/pathname';
 import { useRouter } from '@/i18n/navigation';
@@ -78,7 +78,8 @@ const useLogCreateMutation = () => {
         // GA 이벤트 추적 - 로그 등록 완료
         trackLogCreateEvent('complete');
 
-        const keysToInvalidate = [logKeys.all, searchKeys.all];
+        // 캐시 무효화
+        const keysToInvalidate = [logKeys.all, placeKeys.all, searchKeys.all];
 
         keysToInvalidate.forEach((key) => {
           queryClient.removeQueries({ queryKey: key, exact: false });

--- a/src/hooks/mutations/log/useLogDeleteMutation.ts
+++ b/src/hooks/mutations/log/useLogDeleteMutation.ts
@@ -19,6 +19,8 @@ const useLogDeleteMutation = () => {
     onSuccess: ({ success }) => {
       if (success) {
         toast.success(t('success'));
+
+        //캐시 무효화
         const keysToInvalidate = [logKeys.all, placeKeys.all, searchKeys.all];
 
         keysToInvalidate.forEach((key) => {

--- a/src/hooks/mutations/log/useLogEditMutation.ts
+++ b/src/hooks/mutations/log/useLogEditMutation.ts
@@ -26,6 +26,7 @@ const useLogEditMutation = () => {
 
         clearTag();
 
+        //캐시 무효화
         const keysToInvalidate = [logKeys.all, placeKeys.all, searchKeys.all];
 
         keysToInvalidate.forEach((key) => {


### PR DESCRIPTION
## 📌 작업 주제

홈 화면에서 로그 등록/수정 후 최신 장소 목록이 반영되지 않는 문제 수정

## 🛠 작업 내용

### 버그 수정 (요구사항 기반)

* 로그 등록/수정/삭제 시 장소 캐시가 무효화되지 않아, 최신 장소 목록에 반영되지 않던 문제를 해결함
* 해결 방법:

  * `globalTags` 키 네이밍을 도메인별 `all` 키 (`logKeys.all`, `placeKeys.all` 등)에 맞춰 **일관성 있게 통일**
  * 관련 SSR/CSR 캐시 무효화 지점에서 적절히 `revalidateTag` 또는 `queryClient.removeQueries` 적용

### 구조 개선 및 기타 개선 작업

* NotFound 페이지 진입 시, 상황에 따라 `log`, `place`, `user` 관련 캐시를 SSR/CSR 양쪽에서 무효화할 수 있도록 처리
* SSR/CSR 공유 전략에서 fallback 발생 시, `getLogs` 대신 `fetchLogs`를 직접 호출해 항상 최신 데이터 기준으로 동작하도록 변경
* `PrismaClient`에 싱글톤 패턴 적용 → 핫 리로딩 시 커넥션 풀 과다 생성 방지

