### PR TITLE
NotFound 캐시 무효화 구조 개선, 검색기능 다국어 분기 보완, 상세 페이지 런타임 크래시 방지

### DIFF
--- a/src/app/[locale]/(root)/error.tsx
+++ b/src/app/[locale]/(root)/error.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import ErrorTemplate from '@/components/common/ErrorTemplate';
-
-export default function Error({ error }: { error: Error }) {
-  return <ErrorTemplate message={error.message} />;
-}

--- a/src/app/[locale]/(root)/log/[logId]/not-found.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/not-found.tsx
@@ -1,14 +1,14 @@
 import { logKeys, placeKeys } from '@/app/actions/keys';
-import { revalidateLogs } from '@/app/actions/log';
-import { revalidatePlaces } from '@/app/actions/place';
 import ErrorTemplate from '@/components/common/ErrorTemplate';
 import { getTranslations } from 'next-intl/server';
 
 export default async function NotFound() {
   const t = await getTranslations('NotFoundPage');
-  await revalidateLogs();
-  await revalidatePlaces();
   return (
-    <ErrorTemplate message={t('logMessage')} invalidateKeys={[logKeys.all[0], placeKeys.all[0]]} />
+    <ErrorTemplate
+      message={t('logMessage')}
+      invalidateKeys={[logKeys.all[0], placeKeys.all[0]]}
+      revalidated="detailLog"
+    />
   );
 }

--- a/src/app/[locale]/(root)/log/[logId]/page.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/page.tsx
@@ -16,7 +16,7 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
   const { logId } = await params;
   const result = await getLog(logId);
   if (!result.success) {
-    notFound();
+    return notFound();
   }
   const { data: logData } = result;
   const user = await getUser();
@@ -24,7 +24,7 @@ const LogDetailPage = async ({ params }: LogDetailPageProps) => {
 
   return (
     <div>
-      <LogThumbnail logData={logData} isAuthor={isAuthor} />
+    <LogThumbnail logData={logData} isAuthor={isAuthor} />
       <main className="flex flex-col px-4 web:px-[50px] pb-[200px]">
         <LogAuthorIntro
           userId={logData.user_id}

--- a/src/app/[locale]/(root)/log/[logId]/page.tsx
+++ b/src/app/[locale]/(root)/log/[logId]/page.tsx
@@ -15,16 +15,17 @@ interface LogDetailPageProps {
 const LogDetailPage = async ({ params }: LogDetailPageProps) => {
   const { logId } = await params;
   const result = await getLog(logId);
-  if (!result.success) {
+  if (!result.success || !result.data.place[0]) {
     return notFound();
   }
+
   const { data: logData } = result;
   const user = await getUser();
   const isAuthor = user?.user_id === logData.user_id;
 
   return (
     <div>
-    <LogThumbnail logData={logData} isAuthor={isAuthor} />
+      <LogThumbnail logData={logData} isAuthor={isAuthor} />
       <main className="flex flex-col px-4 web:px-[50px] pb-[200px]">
         <LogAuthorIntro
           userId={logData.user_id}

--- a/src/app/[locale]/(root)/profile/[userId]/not-found.tsx
+++ b/src/app/[locale]/(root)/profile/[userId]/not-found.tsx
@@ -1,10 +1,8 @@
 import { userKeys } from '@/app/actions/keys';
-import { revalidateUsers } from '@/app/actions/user';
 import ErrorTemplate from '@/components/common/ErrorTemplate';
 import { getTranslations } from 'next-intl/server';
 
 export default async function NotFound() {
   const t = await getTranslations('NotFoundPage');
-  await revalidateUsers();
   return <ErrorTemplate message={t('userMessage')} invalidateKeys={[userKeys.all[0]]} />;
 }

--- a/src/app/[locale]/(root)/profile/[userId]/page.tsx
+++ b/src/app/[locale]/(root)/profile/[userId]/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({ params }: ProfilepageProps) {
   const user = isMe ? me : await getPublicUser(userId);
 
   if (!user) {
-    notFound();
+    return notFound();
   }
   return (
     <main className="pt-7.5 web:pt-15 mx-4 web:mx-12.5 mb-35 web:mb-25">

--- a/src/app/api/logs/search/route.ts
+++ b/src/app/api/logs/search/route.ts
@@ -13,6 +13,7 @@ export async function GET(req: NextRequest) {
   const sigungu = searchParams.get('sigungu') || undefined;
   const currentPage = parseInt(searchParams.get('currentPage') || '1', 10);
   const pageSize = parseInt(searchParams.get('pageSize') || '12', 12);
+  const locale = searchParams.get('locale') || 'ko';
 
   try {
     const result = await fetchSearchLogs({
@@ -21,6 +22,7 @@ export async function GET(req: NextRequest) {
       sigungu,
       currentPage,
       pageSize,
+      locale,
     });
 
     revalidateTag(globalTags.searchAll);

--- a/src/app/api/revalidate/detail-log/route.ts
+++ b/src/app/api/revalidate/detail-log/route.ts
@@ -1,0 +1,8 @@
+import { revalidateLogs } from '@/app/actions/log';
+import { revalidatePlaces } from '@/app/actions/place';
+
+export async function GET() {
+  revalidateLogs();
+  revalidatePlaces();
+  return Response.json({ revalidated: true });
+}

--- a/src/app/api/revalidate/user-profile/route.ts
+++ b/src/app/api/revalidate/user-profile/route.ts
@@ -1,0 +1,6 @@
+import { revalidateUsers } from '@/app/actions/user';
+
+export async function GET() {
+  revalidateUsers();
+  return Response.json({ revalidated: true });
+}

--- a/src/components/common/ErrorTemplate.tsx
+++ b/src/components/common/ErrorTemplate.tsx
@@ -10,12 +10,14 @@ interface ErrorTemplateProps {
   title?: string;
   message?: string;
   invalidateKeys?: string[];
+  revalidated?: 'detailLog' | 'profile';
 }
 
 export default function ErrorTemplate({
-  title = '찾으시는 페이지를 찾을 수 없습니다.',
-  message = 'URL 주소를 확인해주세요.',
+  title,
+  message,
   invalidateKeys,
+  revalidated,
 }: ErrorTemplateProps) {
   const router = useRouter();
   const t = useTranslations('NotFoundPage');
@@ -29,13 +31,23 @@ export default function ErrorTemplate({
     }
   }, [invalidateKeys, queryClient]);
 
+  useEffect(() => {
+    if (revalidated === 'detailLog') {
+      fetch('/api/detail-log').then(() => {});
+    }
+    if (revalidated === 'profile') {
+      fetch('/api/user-profile').then(() => {});
+    }
+  }, [revalidated]);
+
   const handleClick = () => router.replace('/');
+
   return (
     <main className="flex flex-col items-center justify-center h-dvh grow">
       <Image src="/images/404.png" alt="404" width={300} height={200} />
       <div className="flex flex-col items-center mt-[50px] mb-5">
-        <h4 className="text-text-xl font-bold">{title ?? t('title')}</h4>
-        <h5 className="text-center">{message ?? t('defaultMessage')}</h5>
+        <h4 className="text-text-xl font-bold">{title ? title : t('title')}</h4>
+        <h5 className="text-center">{message ? message : t('defaultMessage')}</h5>
       </div>
       <Button className="rounded-full mt-5" size={'lg'} onClick={handleClick}>
         홈으로 이동

--- a/src/components/common/ErrorTemplate.tsx
+++ b/src/components/common/ErrorTemplate.tsx
@@ -51,6 +51,7 @@ export default function ErrorTemplate({
       </div>
       <Button className="rounded-full mt-5" size={'lg'} onClick={handleClick}>
         홈으로 이동
+        {t('button')}
       </Button>
     </main>
   );

--- a/src/components/common/ErrorTemplate.tsx
+++ b/src/components/common/ErrorTemplate.tsx
@@ -50,7 +50,6 @@ export default function ErrorTemplate({
         <h5 className="text-center">{message ? message : t('defaultMessage')}</h5>
       </div>
       <Button className="rounded-full mt-5" size={'lg'} onClick={handleClick}>
-        홈으로 이동
         {t('button')}
       </Button>
     </main>

--- a/src/components/features/detail-log/LogThumbnail.tsx
+++ b/src/components/features/detail-log/LogThumbnail.tsx
@@ -21,7 +21,7 @@ const LogThumbnail = ({ logData, isAuthor }: LogThumbnailProps) => {
   return (
     <section className="relative overflow-hidden h-[488px] flex flex-col justify-between px-4 web:px-[50px] pt-4 pb-8">
       <Image
-        src={getStoragePublicImage(place[0].place_images[0].image_path as string)}
+        src={getStoragePublicImage(place[0]?.place_images[0]?.image_path as string)}
         alt="로그 썸네일 이미지"
         fill
         className="object-cover web:blur-md web:scale-110"

--- a/src/hooks/queries/search/useSearchLogs.ts
+++ b/src/hooks/queries/search/useSearchLogs.ts
@@ -16,7 +16,7 @@ export default function useSearchLogs(params: SearchParams) {
   const localeParams = { ...params, locale };
   return useQuery({
     queryKey: searchKeys.list(localeParams),
-    queryFn: () => fetchuseSearch(params),
+    queryFn: () => fetchuseSearch(localeParams),
     placeholderData: keepPreviousData,
     enabled: (params.keyword ?? '').length > 0, // 검색어가 있을 때만
   });


### PR DESCRIPTION
## 📌 작업 주제

NotFound 캐시 무효화 구조 개선, 검색 다국어 분기 버그 수정, 상세 페이지 런타임 크래시 차단

## 🛠 작업 내용

* **NotFound 캐시 무효화 구조 개선**

  * `revalidateTag` 직접 호출 제거, 라우트 핸들러 경유 구조로 분리
  * NotFound 진입 시 로그/장소/유저 캐시 무효화 절차 안정화

* **검색 기능 다국어 분기 보완**

  * 누락된 `locale` 기반 분기 로직 추가

* **상세 페이지 런타임 크래시 차단**

  * `place` 미존재 시 `notFound()` 분기 미적용 되던 문제
  * 다국어 전환/재검증 구간의 `place_images` 누락 상황 404 처리

