### PR TITLE
모달 북마크 시 상세 카운터 미반영 문제 해결

### DIFF
--- a/src/components/features/detail-log/PlaceBookmarkWithCount.tsx
+++ b/src/components/features/detail-log/PlaceBookmarkWithCount.tsx
@@ -2,7 +2,7 @@
 
 import PlaceBookMarkButton from '@/components/common/Button/Bookmark/PlaceBookMarkButton';
 import { formatCount } from '@/lib/utils';
-import { useState } from 'react';
+import { usePlaceBookmarkStore } from '@/stores/placeBookmarkStore';
 
 interface PlaceBookmarkWithCountProps {
   placeId: string;
@@ -13,19 +13,12 @@ export default function PlaceBookmarkWithCount({
   placeId,
   placeBookmarkCount = 0,
 }: PlaceBookmarkWithCountProps) {
-  const [bookmarkCount, setBookmarkCount] = useState(placeBookmarkCount);
+  const count = usePlaceBookmarkStore((state) => state.counts[placeId] ?? placeBookmarkCount);
 
-  const handleToggle = (newStatus: boolean) => {
-    setBookmarkCount((prev) => prev + (newStatus ? 1 : -1));
-  };
   return (
     <section className="absolute top-0 right-0 flex flex-col items-center">
-      <PlaceBookMarkButton
-        placeId={placeId}
-        onToggle={handleToggle}
-        className="!top-0 !right-0 !relative w-9 h-9"
-      />
-      <span className="font-medium text-text-sm text-light-300">{formatCount(bookmarkCount)}</span>
+      <PlaceBookMarkButton placeId={placeId} className="!top-0 !right-0 !relative w-9 h-9" />
+      <span className="font-medium text-text-sm text-light-300">{formatCount(count)}</span>
     </section>
   );
 }

--- a/src/hooks/mutations/place/usePlaceBookmarkMutation.ts
+++ b/src/hooks/mutations/place/usePlaceBookmarkMutation.ts
@@ -1,5 +1,6 @@
 import { placeKeys } from '@/app/actions/keys';
 import useUser from '@/hooks/queries/user/useUser';
+import { usePlaceBookmarkStore } from '@/stores/placeBookmarkStore';
 import { BookmarkResponse } from '@/types/api/common';
 import { PlaceBookmarkParams } from '@/types/api/place';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -22,6 +23,8 @@ export default function usePlaceBookmarkMutation(onToggle?: (newStatus: boolean)
   const { data: user } = useUser();
   const queryClient = useQueryClient();
 
+  const onBookmark = usePlaceBookmarkStore((state) => state.onBookmark);
+
   return useMutation({
     mutationFn: (params: PlaceBookmarkParams) => fetchPlaceBookmark({ ...params, locale }),
     onMutate: async ({ placeId, isBookmark }: PlaceBookmarkParams) => {
@@ -43,6 +46,9 @@ export default function usePlaceBookmarkMutation(onToggle?: (newStatus: boolean)
 
       // 상세페이지 카운트 반영
       onToggle?.(!isBookmark);
+
+      // 전역 상태 낙관적 업데이트
+      onBookmark(placeId, isBookmark);
 
       return { previousData };
     },

--- a/src/stores/placeBookmarkStore.ts
+++ b/src/stores/placeBookmarkStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+type Counts = Record<string, number>;
+
+type State = {
+  counts: Counts;
+};
+type Actions = {
+  setCount: (placeId: string, count: number) => void;
+  onBookmark: (placeId: string, isBookmarked: boolean) => void;
+};
+
+export const usePlaceBookmarkStore = create<State & Actions>((set) => ({
+  counts: {},
+  setCount: (placeId, count) =>
+    set((state) => ({
+      counts: { ...state.counts, [placeId]: Math.max(0, count) },
+    })),
+
+  onBookmark: (placeId, isBookmarked) =>
+    set((state) => {
+      const current = state.counts[placeId] ?? 0;
+      const delta = isBookmarked ? -1 : 1; // 북마크 해제면 -1, 등록이면 +1
+      return {
+        counts: {
+          ...state.counts,
+          [placeId]: Math.max(0, current + delta),
+        },
+      };
+    }),
+}));


### PR DESCRIPTION
## 📌 작업 주제

상세페이지 모달 북마크 시 카운터 미반영 문제 해결

## 🛠 작업 내용

* **전역 store 추가**

  * 장소 북마크 카운트를 `counts: Record<placeId, number>` 형태로 전역 관리
  * `setCount`로 서버 값 초기화, `onBookmark`로 낙관적 증감 처리

* **카운트 구독 리팩터**

  * `PlaceBookmarkWithCount`의 로컬 `useState` 제거
  * 전역 store 구독으로 변경 → 다른 컴포넌트에서 토글해도 즉시 반영

* **버튼 낙관적 업데이트 연동**

  * `PlaceBookMarkButton` 클릭 시 `onBookmark` 호출 후 `mutate` 실행
  * 모달에서 북마크 토글해도 상세페이지 카운터가 바로 동기화

## 📚 추가 내용 (선택)

* 화면별로 따로 놀던 카운트를 하나로 합쳐, 어떤 화면에서 북마크를 눌러도 모두 동시에 반영되도록 수정
* 원래는 **TanStack Query 낙관적 업데이트**로 구현하려 했으나 과하다고 판단
* 대신 **Zustand 전역 상태**로 단순 관리해 모달, 상세, 리스트 모두 즉시 반영되도록 함
