### PR TITLE
글로벌 버전 위치 검색 오류 수정

### DIFF
--- a/src/components/common/Card/PostCard/PostCardLocation.tsx
+++ b/src/components/common/Card/PostCard/PostCardLocation.tsx
@@ -21,12 +21,12 @@ function PostCardLocation({ city, country = '', sigungu, category, modal }: Post
         <span>{t(`Category.${category}`)}</span>
       ) : (
         <>
-          {city && <span>{t(`Region.${city}`)}</span>}
+          {city && <span>{city}</span>}
           <div className="h-3 inline-block align-middle">
             <Separator orientation="vertical" className="h-3 bg-light-300" />
           </div>
-          {country && <span>{t(`CountryType.${country}`)}</span>}
-          {sigungu && <span>{t(`Region.${sigungu}`)}</span>}
+          {country && <span>{country}</span>}
+          {sigungu && <span>{sigungu}</span>}
         </>
       )}
     </h4>

--- a/src/contexts/LogRegisterContext.tsx
+++ b/src/contexts/LogRegisterContext.tsx
@@ -8,6 +8,7 @@ import { PlaceWithoutImages, useLogFormStore } from '@/stores/logFormStore';
 import { useLogTagStore } from '@/stores/logTagStore';
 import { LogCreateValues, LogFormValues } from '@/types/log';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslations } from 'next-intl';
 import {
   ReactNode,
   createContext,
@@ -39,6 +40,9 @@ export const useLogForm = () => {
 };
 
 export const LogFormProvider = ({ children }: { children: ReactNode }) => {
+  const tRegister = useTranslations('Register.CountryPage.options');
+  const tRegion = useTranslations('Region');
+
   const country = useLogTagStore((state) => state.country);
   const city = useLogTagStore((state) => state.city);
   const sigungu = useLogTagStore((state) => state.sigungu);
@@ -73,9 +77,9 @@ export const LogFormProvider = ({ children }: { children: ReactNode }) => {
           activity,
         },
         address: {
-          country,
-          city,
-          sigungu,
+          country: tRegister(country),
+          city: tRegion(city),
+          sigungu: tRegion(sigungu),
         },
       };
 


### PR DESCRIPTION
## 📌 작업 주제

* 글로벌 버전에서 로그 위치(city, country, sigungu)가 DB에 한글로만 저장되어 영어 검색이 불가능한 문제를 수정

## 🛠 작업 내용

* **PostCardLocation**

  * 기존: city, country, sigungu를 `useTranslations`로 번역해서 표시
  * 변경: DB에 저장된 값을 그대로 출력하도록 수정
  * 목적: 이후 저장 로직을 한국/글로벌 버전에 맞게 번역 저장하도록 변경하면서, UI와 DB 저장값을 일관되게 맞추기 위함

* **LogFormProvider**

  * 기존: 글로벌 버전 로그 등록 시에도 한글 값이 DB에 저장되어 영어 검색 불가
  * 변경: 로그 등록 시 `city, country, sigungu`를 로케일에 맞춰 번역된 문자열로 DB에 저장

    * 한국 버전 → 한글 저장
    * 글로벌 버전 → 영어 저장
  * 효과: 글로벌 버전에서 영어 검색 시 정상적으로 결과 조회 가능, 한국 버전은 기존과 동일하게 동작

## 📚 추가 내용 (선택)

* PostCardLocation은 단순히 DB 저장값을 그대로 보여주도록 정리한 것으로, 직접적인 버그 수정이 아니라 저장 로직 변경과의 일관성을 맞추기 위한 작업
* 이번 수정으로 검색 및 UI 모두 로케일에 맞게 동작하며, 글로벌 사용자의 검색 경험이 개선
